### PR TITLE
WIP: docs: add GlobalLayout to fit dumi docs theme config

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -1,0 +1,21 @@
+import { ConfigProvider, theme } from 'antd';
+// @ts-ignore dumi 实际上导出了
+import { useOutlet, usePrefersColor } from 'dumi';
+import React from 'react';
+
+const GlobalLayout: React.FC = () => {
+  const outlet = useOutlet();
+  const [color] = usePrefersColor();
+
+  return (
+    <ConfigProvider
+      theme={{
+        algorithm: color === 'dark' ? theme.darkAlgorithm : theme.defaultAlgorithm,
+      }}
+    >
+      {outlet}
+    </ConfigProvider>
+  );
+};
+
+export default GlobalLayout;

--- a/.dumi/tsconfig.json
+++ b/.dumi/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,4 @@ jspm_packages/
 # Build
 dist
 docs-dist
-.dumi
+.dumi/tmp

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -8,7 +8,8 @@
     "./*.?*.ts",
     "src",
     // test workspace lint
-    "__tests__"
+    "__tests__",
+    ".dumi/theme"
   ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/da3be002-9da5-4e05-afd0-3296fd3bff4b)

原本想适配下文档的主题切换，但是发现我们的 demo 框架都没适配多主题，所以先把 dumi/theme 配置提上来。
待其他都适配了可以合并接入，cc @lvisei 

当前整体效果：
![image](https://github.com/user-attachments/assets/78f864a7-cd8f-4b3d-b9d1-040365aa9efe)

![image](https://github.com/user-attachments/assets/9df21d57-ec3f-4322-8003-26d63cfee090)

备注：文本类组件的 demo 我另外提一个 pr 处理
