### PR TITLE
fix(text): modify the judgment rules of dark mode

### DIFF
--- a/.changeset/old-shirts-train.md
+++ b/.changeset/old-shirts-train.md
@@ -1,0 +1,5 @@
+---
+'@antv/gpt-vis': patch
+---
+
+fix(text): modify the judgment rules of dark mode

--- a/bindings/streamlit-gpt-vis/streamlit_gpt_vis/frontend/public/bootstrap.min.css
+++ b/bindings/streamlit-gpt-vis/streamlit_gpt_vis/frontend/public/bootstrap.min.css
@@ -31,11 +31,11 @@
   --breakpoint-md: 768px;
   --breakpoint-lg: 992px;
   --breakpoint-xl: 1200px;
-  --font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
-    Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
-  --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
-    'Courier New', monospace;
+  --font-family-sans-serif:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-family-monospace:
+    SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 }
 *,
 ::after,
@@ -62,9 +62,9 @@ section {
 }
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
-    'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;
@@ -5705,9 +5705,9 @@ a.close.disabled {
   z-index: 1070;
   display: block;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
-    'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   font-style: normal;
   font-weight: 400;
   line-height: 1.5;
@@ -5815,9 +5815,9 @@ a.close.disabled {
   z-index: 1060;
   display: block;
   max-width: 276px;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
-    'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   font-style: normal;
   font-weight: 400;
   line-height: 1.5;
@@ -9234,7 +9234,8 @@ button.bg-dark:hover {
   background-color: rgba(0, 0, 0, 0);
 }
 .text-monospace {
-  font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
+  font-family:
+    SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace !important;
 }
 .text-justify {
   text-align: justify !important;

--- a/src/Text/utils/useAntdDarkAlgorithm.ts
+++ b/src/Text/utils/useAntdDarkAlgorithm.ts
@@ -11,5 +11,5 @@ export const useAntdDarkAlgorithm = () => {
   const currentAlgorithm = config.theme?.algorithm;
 
   if (isArray(currentAlgorithm) && currentAlgorithm.includes(darkAlgorithm)) return true;
-  return currentAlgorithm === darkAlgorithm;
+  return !!darkAlgorithm && currentAlgorithm === darkAlgorithm;
 };


### PR DESCRIPTION
### PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos

### Description
使用VisText时，如果调用方使用antd 4，会识别成暗黑模式，导致ntv短语看不清

### Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/9b9b0a22-25ad-47f3-af86-8b9acac3a3a0) | ![image](https://github.com/user-attachments/assets/b52fb21a-deb7-48a6-9239-4abe061eca82)|
