### PR TITLE
修复 dual-axes 双轴图渲染崩溃问题

### DIFF
--- a/bindings/gpt-vis-ssr/src/vis/dual-axes.ts
+++ b/bindings/gpt-vis-ssr/src/vis/dual-axes.ts
@@ -74,7 +74,7 @@ export async function DualAxes(options: DualAxesOptions) {
         return ORDER.indexOf(a.type) - ORDER.indexOf(b.type);
       })
       .map((item: any) => {
-        const { type, axisYTitle, ...others } = item;
+        const { type, axisYTitle, data, ...others } = item;
 
         const baseConfig = {
           ...others,
@@ -97,7 +97,6 @@ export async function DualAxes(options: DualAxesOptions) {
               ...(texture === 'rough' ? { itemLabelFontFamily: FontFamily.ROUGH } : {}),
             },
           },
-          data: undefined,
         };
 
         if (type === ChartType.Column) {


### PR DESCRIPTION
我个人名义提交下修改吧

## 问题
  dual-axes 图表在 SSR 渲染时崩溃

  ## 原因
  - baseConfig 中设置了 `data: undefined`（第100行）
  - `...others` 将原始 `data` 数组错误传递到子配置

  ## 修复
  - 第77行：添加 `data` 到解构中排除它：`const { type, axisYTitle, data, ...others }`
  - 第100行：删除 `data: undefined,`

  ## 测试
  修复后以下数据可正常渲染：
<img width="1800" height="1200" alt="7b846578-f7ac-4a33-8a95-4e9c21bb3361" src="https://github.com/user-attachments/assets/c398ef26-b608-4b72-bdd6-1ec3488f2429" />
  ```json
  {
    "type": "dual-axes",
    "title": "Sales and Growth Rate Analysis",
    "axisXTitle": "Month",
    "categories": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
    "series": [
      {
        "type": "column",
        "data": [120, 200, 150, 180, 220, 260, 210, 190, 240, 280, 310, 350],
        "axisYTitle": "Sales (K)"
      },
      {
        "type": "line",
        "data": [0.12, 0.67, -0.25, 0.20, 0.22, 0.18, -0.19, -0.10, 0.26, 0.17, 0.11, 0.13],
        "axisYTitle": "Growth Rate"
      }
    ]
  }
