### PR TITLE
fix(ChartCodeRender): loading text follows locale settings

### DIFF
--- a/.changeset/fix-loading-locale-text.md
+++ b/.changeset/fix-loading-locale-text.md
@@ -1,0 +1,5 @@
+---
+'@antv/gpt-vis': patch
+---
+
+fix(ChartCodeRender): loading text follows locale settings

--- a/src/ChartCodeRender/Loading.tsx
+++ b/src/ChartCodeRender/Loading.tsx
@@ -16,13 +16,17 @@ const StyledLoading = styled.div`
   }
 `;
 
-const Loading = () => {
+type LoadingProps = {
+  text: string;
+};
+
+const Loading: React.FC<LoadingProps> = ({ text }) => {
   return (
     <StyledLoading className="gpt-vis-loading">
       <div className="gpt-vis-loading-icon">
         <LoadingOutlined style={{ fontSize: '24px', color: 'rgb(56, 177, 246)' }} />
       </div>
-      <p>数据生成中</p>
+      <p>{text}</p>
     </StyledLoading>
   );
 };

--- a/src/ChartCodeRender/VisChart.tsx
+++ b/src/ChartCodeRender/VisChart.tsx
@@ -53,6 +53,7 @@ const DEFAULT_LABELS: Record<string, TextLabels> = {
     renderError: '图表渲染失败',
     parseError: 'GPT-Vis parse content error!',
     unsupportedChart: 'Chart type not supported',
+    loading: '数据生成中',
   },
   'en-US': {
     chartTab: 'Chart',
@@ -63,6 +64,7 @@ const DEFAULT_LABELS: Record<string, TextLabels> = {
     renderError: 'Chart render failed',
     parseError: 'Parse content error!',
     unsupportedChart: 'Chart type not supported',
+    loading: 'Generating data',
   },
   'pt-BR': {
     chartTab: 'Gráfico',
@@ -73,6 +75,7 @@ const DEFAULT_LABELS: Record<string, TextLabels> = {
     renderError: 'Erro ao renderizar gráfico',
     parseError: 'Erro ao analisar conteúdo!',
     unsupportedChart: 'Tipo de gráfico não suportado',
+    loading: 'Gerando dados',
   },
 };
 
@@ -161,7 +164,7 @@ export const RenderVisChart: React.FC<RenderVisChartProps> = memo(
       if (loading) {
         return (
           <StyledGPTVis className="gpt-vis" style={style}>
-            <Loading />
+            <Loading text={labels.loading || ''} />
           </StyledGPTVis>
         );
       }

--- a/src/ChartCodeRender/type.ts
+++ b/src/ChartCodeRender/type.ts
@@ -14,6 +14,7 @@ export type TextLabels = {
   renderError?: string; // Render error text | 渲染错误文本
   parseError?: string; // Parse error text | 解析错误文本
   unsupportedChart?: string; // Unsupported chart type text | 不支持的图表类型文本
+  loading?: string; // Loading text | 加载中文本
 };
 
 /**


### PR DESCRIPTION
## Summary
Fix the hardcoded Chinese text "数据生成中" in the Loading component to follow the locale system.

## Changes
- Added `loading` field to `TextLabels` type in `type.ts`
- Added loading text translations for all supported locales in `VisChart.tsx`:
  - `zh-CN`: "数据生成中"
  - `en-US`: "Generating data"
  - `pt-BR`: "Gerando dados"
- Updated `Loading.tsx` component to accept a `text` prop
- Updated `RenderVisChart` to pass the localized loading text to the `Loading` component

## Before
The Loading component always displayed "数据生成中" regardless of the locale setting.

## After
The Loading component now displays the appropriate text based on the configured locale.