### PR TITLE
Update homepage and add missing charts

### DIFF
--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -69,7 +69,7 @@ export default function Home() {
 
           <p className="text-xl text-gray-600 mb-10 max-w-3xl mx-auto leading-relaxed">
             Framework-agnostic visualization library designed for AI-powered applications. Simple
-            syntax that LLMs generate effortlessly. 16 chart types ready for your AI agents.
+            syntax that LLMs generate effortlessly. 25 chart types ready for your AI agents.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-16">
@@ -157,7 +157,7 @@ gptVis.render(visSyntax);`}</code>
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
             <h2 className="text-4xl md:text-5xl font-bold mb-4 text-gray-900">
-              16 AI-Friendly Chart Types
+              25 AI-Friendly Chart Types
             </h2>
             <p className="text-xl text-gray-600 max-w-2xl mx-auto">
               From basic statistical charts to advanced visualizations
@@ -394,6 +394,15 @@ const chartTypes = [
   'Treemap',
   'Venn',
   'Table',
+  'Dual Axes',
+  'Liquid',
+  'Word Cloud',
+  'Flow Diagram',
+  'Network Graph',
+  'Mindmap',
+  'Indented Tree',
+  'Organization Chart',
+  'Summary',
 ];
 
 const frameworks = [
@@ -435,6 +444,15 @@ function getChartIcon(chart: string): string {
     Treemap: '🗺️',
     Venn: '⭕',
     Table: '📋',
+    'Dual Axes': '📉',
+    Liquid: '💧',
+    'Word Cloud': '☁️',
+    'Flow Diagram': '🔄',
+    'Network Graph': '🕸️',
+    Mindmap: '🧠',
+    'Indented Tree': '🌳',
+    'Organization Chart': '🏢',
+    Summary: '📝',
   };
   return icons[chart] || '📊';
 }

--- a/skills/chart-visualization/SKILL.md
+++ b/skills/chart-visualization/SKILL.md
@@ -15,7 +15,7 @@ This skill helps AI assistants recommend and generate appropriate data visualiza
    - Proportion analysis → Pie chart
    - Distribution analysis → Histogram, Boxplot, Violin charts
    - Relationship/Flow → Sankey chart, Flow Diagram
-   - Hierarchical/Tree → Mind Map, Indented Tree, Organization Chart
+   - Hierarchical/Tree → Mindmap, Indented Tree, Organization Chart
    - Process/Steps → Flow Diagram
    - Entity Relations → Network Graph
    - Multi-dimensional comparison → Radar chart

--- a/skills/chart-visualization/SKILL.md
+++ b/skills/chart-visualization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chart-visualization
-description: Recommend and generate appropriate data visualizations using GPT-Vis syntax. Supports 22 chart types including statistical charts (line, column, bar, pie, area, scatter, dual-axes, histogram, boxplot, radar, funnel, waterfall, liquid, word-cloud, violin, venn, treemap), flow charts (sankey, flow-diagram), relation charts (mindmap), and data display (table, summary). Provides workflow from intent recognition to chart selection, syntax generation, and code generation for HTML, React, or Vue.
+description: Recommend and generate appropriate data visualizations using GPT-Vis syntax. Supports 25 chart types including statistical charts (line, column, bar, pie, area, scatter, dual-axes, histogram, boxplot, radar, funnel, waterfall, liquid, word-cloud, violin, venn, treemap), flow charts (sankey, flow-diagram), relation charts (mindmap, indented-tree, network-graph, organization-chart), and data display (table, summary). Provides workflow from intent recognition to chart selection, syntax generation, and code generation for HTML, React, or Vue.
 ---
 
 # Chart Visualization Skill
@@ -15,8 +15,9 @@ This skill helps AI assistants recommend and generate appropriate data visualiza
    - Proportion analysis → Pie chart
    - Distribution analysis → Histogram, Boxplot, Violin charts
    - Relationship/Flow → Sankey chart, Flow Diagram
-   - Hierarchical/Tree → Mind Map
+   - Hierarchical/Tree → Mind Map, Indented Tree, Organization Chart
    - Process/Steps → Flow Diagram
+   - Entity Relations → Network Graph
    - Multi-dimensional comparison → Radar chart
    - Other specific needs → Funnel, Waterfall, Liquid, WordCloud, Treemap, Venn, etc.
 
@@ -47,7 +48,10 @@ This skill helps AI assistants recommend and generate appropriate data visualiza
 | 矩阵树图 | 树状图     | Treemap         | 显示层级数据占比           | 层级占比、结构分析 |
 | 桑基图   | -          | Sankey Chart    | 展示流量流向               | 流向分析           |
 | 流程图   | Dagre 图   | Flow Diagram    | 展示流程步骤和决策点       | 流程分析、决策展示 |
-| 思维导图 | 脑图       | Mind Map        | 核心主题层级展开           | 层级分析、知识梳理 |
+| 思维导图   | 脑图         | Mind Map            | 核心主题层级展开           | 层级分析、知识梳理 |
+| 缩进树     | 层级树、目录树 | Indented Tree      | 展示树节点层级和目录结构   | 层级分析、目录展示 |
+| 网络图     | 关系图、力导向图 | Network Graph    | 展示实体间复杂关联关系     | 关系分析、网络分析 |
+| 组织架构图 | 组织结构图   | Organization Chart  | 展示组织层级和部门关系     | 层级分析、组织展示 |
 | 表格     | 数据表     | Table           | 展示详细数据明细           | 数据展示、查找     |
 | 总结摘要 | -          | Summary         | 文本总结内容               | 内容总结           |
 
@@ -631,6 +635,72 @@ title 项目计划
 ```
 
 详细用法参考: [references/mindmap.md](references/mindmap.md)
+
+### Indented Tree (缩进树)
+
+**适用场景**: 通过水平缩进展示树节点层级关系，适合文件目录、分类体系等
+
+**Syntax 示例**:
+
+```
+vis indented-tree
+data
+  name my-project
+  children
+    - name src
+      children
+        - name components
+        - name pages
+    - name public
+    - name package.json
+title 项目目录结构
+```
+
+详细用法参考: [references/indented-tree.md](references/indented-tree.md)
+
+### Network Graph (网络图)
+
+**适用场景**: 展示实体之间的复杂关联关系，如社交网络、知识图谱
+
+**Syntax 示例**:
+
+```
+vis network-graph
+data
+  nodes
+    - name 哈利·波特
+    - name 赫敏·格兰杰
+    - name 伏地魔
+  edges
+    - source 哈利·波特
+      target 赫敏·格兰杰
+      name 朋友
+    - source 哈利·波特
+      target 伏地魔
+      name 敌人
+```
+
+详细用法参考: [references/network-graph.md](references/network-graph.md)
+
+### Organization Chart (组织架构图)
+
+**适用场景**: 展示组织内部层级结构和部门关系
+
+**Syntax 示例**:
+
+```
+vis organization-chart
+data
+  name 首席执行官
+  description CEO
+  children
+    - name 首席技术官
+      description CTO
+    - name 首席财务官
+      description CFO
+```
+
+详细用法参考: [references/organization-chart.md](references/organization-chart.md)
 
 ### Table (表格)
 

--- a/skills/chart-visualization/SKILL.md
+++ b/skills/chart-visualization/SKILL.md
@@ -48,7 +48,7 @@ This skill helps AI assistants recommend and generate appropriate data visualiza
 | 矩阵树图 | 树状图     | Treemap         | 显示层级数据占比           | 层级占比、结构分析 |
 | 桑基图   | -          | Sankey Chart    | 展示流量流向               | 流向分析           |
 | 流程图   | Dagre 图   | Flow Diagram    | 展示流程步骤和决策点       | 流程分析、决策展示 |
-| 思维导图   | 脑图         | Mind Map            | 核心主题层级展开           | 层级分析、知识梳理 |
+| 思维导图   | 脑图         | Mindmap            | 核心主题层级展开           | 层级分析、知识梳理 |
 | 缩进树     | 层级树、目录树 | Indented Tree      | 展示树节点层级和目录结构   | 层级分析、目录展示 |
 | 网络图     | 关系图、力导向图 | Network Graph    | 展示实体间复杂关联关系     | 关系分析、网络分析 |
 | 组织架构图 | 组织结构图   | Organization Chart  | 展示组织层级和部门关系     | 层级分析、组织展示 |

--- a/skills/chart-visualization/references/indented-tree.md
+++ b/skills/chart-visualization/references/indented-tree.md
@@ -1,0 +1,133 @@
+## 图表属性
+
+- 名称：缩进树
+- 别名：层级树、目录树，英文名：Indented Tree
+- 形状：树形
+- 图表类别：关系图
+- 图表功能：通过水平缩进展示树节点的层级关系
+
+## 基础概念
+
+缩进树通过水平方向的缩进量来表示树节点层级的布局方式。每个元素占据一行，父节点在上方，子节点以缩进的方式排列在下方，层层缩进直观地展示出节点的深度和从属关系。常用于文件目录结构、组织层级、分类体系等需要清晰展示层级关系的场景。
+
+## 适用场景
+
+- 展示文件目录结构，如项目文件树、磁盘目录浏览。
+- 展示分类体系，如产品分类、知识体系目录。
+- 展示组织层级关系，侧重于展示层级的深度和数量。
+- 展示软件包依赖关系或模块引用关系。
+- 需要在有限宽度内展示较深层级的树形数据。
+
+## 不适用场景
+
+1. 节点之间存在交叉引用（非树形结构），更推荐使用网络图。
+2. 需要对比节点间数量大小关系，更推荐使用柱状图或树图。
+3. 数据层级超过 10 层，视觉效果会很拥挤。
+4. 需要展示以核心主题为中心双向辐射的层级，更推荐使用思维导图。
+
+## 图表用法
+
+### 图表属性
+
+```typescript
+type IndentedTreeData = {
+  name: string;
+  children?: IndentedTreeData[];
+};
+
+type IndentedTree = {
+  type: 'indented-tree';
+   IndentedTreeData;
+  direction?: 'LR' | 'RL' | 'H';
+  title?: string;
+  theme?: 'default' | 'dark' | 'academy';
+  style?: {
+    backgroundColor?: string;
+    palette?: string[];
+  };
+};
+```
+
+### 数据要求
+
+- type：图表的类型，必填，文本类型，值必须为 "indented-tree"。
+- data：图表的数据，必填，`IndentedTreeData` 对象类型，包含以下字段：
+  - name：节点的名称，必填，字符串类型；
+  - children：当前节点的子节点集合，选填，数组对象类型。如果当前节点没有子节点，该字段可以省略。每个子节点本身也是一个 `IndentedTreeData` 对象，可以递归构建多层次的树状结构；
+- direction：布局方向，选填，文本类型，可选值为 "LR"（根节点在左，向右展开，默认）、"RL"（根在右，向左展开）、"H"（根在中间，双向展开）。
+- title：图表标题，选填，文本类型。
+- theme：图表主题，选填，文本类型，可选值为 "default" | "dark" | "academy"，默认值为 "default"。
+- style：图表样式，选填，对象类型；
+  - palette：颜色映射，选填，数组类型，合法颜色值数组。
+  - backgroundColor：背景颜色，选填，文本类型，合法颜色值。
+
+## 使用示例
+
+1. 前端项目的目录结构，包含 src、public、package.json，其中 src 下有 components、pages、utils 三个文件夹。
+
+```
+vis indented-tree
+data
+  name my-project
+  children
+    - name src
+      children
+        - name components
+          children
+            - name Button
+            - name Modal
+        - name pages
+          children
+            - name Home
+            - name About
+        - name utils
+    - name public
+    - name package.json
+title 项目目录结构
+```
+
+2. 人工智能知识体系分类，从根节点向右展开，包含机器学习和深度学习两大分支。
+
+```
+vis indented-tree
+data
+  name 人工智能
+  children
+    - name 机器学习
+      children
+        - name 监督学习
+        - name 无监督学习
+        - name 强化学习
+    - name 深度学习
+      children
+        - name 卷积神经网络
+        - name 循环神经网络
+direction LR
+title 人工智能知识体系
+```
+
+3. 公司部门层级结构，双向展开，dark 主题，自定义配色。
+
+```
+vis indented-tree
+data
+  name 公司
+  children
+    - name 技术部
+      children
+        - name 前端组
+        - name 后端组
+        - name 测试组
+    - name 产品部
+      children
+        - name 产品设计组
+        - name 用户研究组
+    - name 运营部
+      children
+        - name 市场推广组
+        - name 用户运营组
+direction H
+theme dark
+style
+  palette #5B8FF9 #61DDAA #65789B #F6BD16 #7262FD
+```

--- a/skills/chart-visualization/references/indented-tree.md
+++ b/skills/chart-visualization/references/indented-tree.md
@@ -37,7 +37,7 @@ type IndentedTreeData = {
 
 type IndentedTree = {
   type: 'indented-tree';
-   IndentedTreeData;
+  data: IndentedTreeData;
   direction?: 'LR' | 'RL' | 'H';
   title?: string;
   theme?: 'default' | 'dark' | 'academy';

--- a/skills/chart-visualization/references/network-graph.md
+++ b/skills/chart-visualization/references/network-graph.md
@@ -42,7 +42,7 @@ type NetworkGraphEdge = {
 
 type NetworkGraph = {
   type: 'network-graph';
-   {
+  data: {
     nodes: NetworkGraphNode[];
     edges: NetworkGraphEdge[];
   };

--- a/skills/chart-visualization/references/network-graph.md
+++ b/skills/chart-visualization/references/network-graph.md
@@ -1,0 +1,177 @@
+## 图表属性
+
+- 名称：网络图
+- 别名：关系网络图、关系图、力导向图，英文名：Network Graph、Force Graph
+- 形状：网络形
+- 图表类别：关系图
+- 图表功能：展示实体之间的关系和连接
+
+## 基础概念
+
+网络图（Network Graph）是一种展示实体（节点）之间的关系（边）的图。通过节点和边的连接，直观地表示复杂的网络结构。每个节点代表一个实体，而每条边则表示两个节点之间的关系或连接。
+
+网络图的关键就是展示"谁跟谁有联系"。比如，节点代表人，连线代表某两个人之间是否认识。支持多种布局方式：力导向（force）、环形（circular）、网格（grid）、辐射（radial）、同心圆（concentric）、层次（dagre）。
+
+## 适用场景
+
+- 展示实体之间的关系，例如社交网络中的人际关系。
+- 分析复杂网络结构中的模式和特性，例如通信网络中的节点连接情况。
+- 展示数据之间的关联性和依赖关系，例如知识图谱中的概念关联。
+
+## 不适用场景
+
+1. 线性流程：需要展示线性流程或步骤的场景，用流程图更合适。
+2. 独立数据点：数据点之间没有明显关系或连接，用散点图更为合适。
+3. 层次结构：需要展示明确上下级层次结构的场景，用组织架构图或思维导图更合适。
+4. 连续叙事：当具有明确的顺序关系或变化趋势时，用折线图或面积图更为适合。
+
+## 图表用法
+
+### 图表属性
+
+```typescript
+type NetworkGraphNode = {
+  name: string;
+};
+
+type NetworkGraphEdge = {
+  source: string;
+  target: string;
+  name?: string;
+};
+
+type NetworkGraph = {
+  type: 'network-graph';
+   {
+    nodes: NetworkGraphNode[];
+    edges: NetworkGraphEdge[];
+  };
+  layout?: 'force' | 'circular' | 'grid' | 'radial' | 'concentric' | 'dagre';
+  title?: string;
+  theme?: 'default' | 'dark' | 'academy';
+  style?: {
+    backgroundColor?: string;
+    palette?: string[];
+  };
+};
+```
+
+### 数据要求
+
+- type：图表的类型，必填，文本类型，值必须为 "network-graph"。
+- data：图表的数据，必填，对象类型，包含以下字段：
+  - nodes：网络图中的节点数组，每个节点表示一个实体，必填，数组对象类型；
+    - name：节点的名称，必须唯一，用于标识节点，必填，文本类型；
+  - edges：网络图中的边数组，每条边表示两个节点之间的关系，必填，数组对象类型；
+    - source：边的起始节点名称，指向节点的 `name` 属性，必填，文本类型；
+    - target：边的目标节点名称，指向节点的 `name` 属性，必填，文本类型；
+    - name：边的名称，用于标识关系类型，选填，文本类型；
+- layout：布局方式，选填，文本类型，可选值为 "force"（力导向，默认）| "circular"（环形）| "grid"（网格）| "radial"（辐射）| "concentric"（同心圆）| "dagre"（层次）。
+- title：图表标题，选填，文本类型。
+- theme：图表主题，选填，文本类型，可选值为 "default" | "dark" | "academy"，默认值为 "default"。
+- style：图表样式，选填，对象类型；
+  - palette：颜色映射，选填，数组类型，合法颜色值数组。
+  - backgroundColor：背景颜色，选填，文本类型，合法颜色值。
+
+## 使用示例
+
+1. 《哈利波特》主要人物关系，展示哈利·波特与伙伴及对手之间的关系。
+
+```
+vis network-graph
+data
+  nodes
+    - name 哈利·波特
+    - name 赫敏·格兰杰
+    - name 罗恩·韦斯莱
+    - name 伏地魔
+  edges
+    - source 哈利·波特
+      target 赫敏·格兰杰
+      name 朋友
+    - source 哈利·波特
+      target 罗恩·韦斯莱
+      name 朋友
+    - source 哈利·波特
+      target 伏地魔
+      name 敌人
+    - source 伏地魔
+      target 哈利·波特
+      name 试图杀死
+title 哈利波特人物关系
+```
+
+2. 微服务系统的服务依赖关系，使用层次布局，academy 主题。
+
+```
+vis network-graph
+data
+  nodes
+    - name API 网关
+    - name 用户服务
+    - name 订单服务
+    - name 商品服务
+    - name 支付服务
+    - name 消息队列
+    - name 数据库
+  edges
+    - source API 网关
+      target 用户服务
+      name 请求转发
+    - source API 网关
+      target 订单服务
+      name 请求转发
+    - source API 网关
+      target 商品服务
+      name 请求转发
+    - source 订单服务
+      target 支付服务
+      name 调用
+    - source 订单服务
+      target 消息队列
+      name 发布消息
+    - source 用户服务
+      target 数据库
+      name 读写
+    - source 订单服务
+      target 数据库
+      name 读写
+layout dagre
+theme academy
+title 微服务依赖关系
+```
+
+3. 知识图谱概念关联，环形布局，dark 主题，自定义配色。
+
+```
+vis network-graph
+data
+  nodes
+    - name 机器学习
+    - name 深度学习
+    - name 神经网络
+    - name 自然语言处理
+    - name 计算机视觉
+    - name 强化学习
+  edges
+    - source 机器学习
+      target 深度学习
+      name 包含
+    - source 深度学习
+      target 神经网络
+      name 基于
+    - source 深度学习
+      target 自然语言处理
+      name 应用于
+    - source 深度学习
+      target 计算机视觉
+      name 应用于
+    - source 机器学习
+      target 强化学习
+      name 包含
+layout circular
+theme dark
+style
+  palette #5B8FF9 #61DDAA #65789B #F6BD16 #7262FD
+title AI 知识图谱
+```

--- a/skills/chart-visualization/references/organization-chart.md
+++ b/skills/chart-visualization/references/organization-chart.md
@@ -38,7 +38,7 @@ type OrganizationChartData = {
 
 type OrganizationChart = {
   type: 'organization-chart';
-   OrganizationChartData;
+  data: OrganizationChartData;
   title?: string;
   theme?: 'default' | 'dark' | 'academy';
   style?: {

--- a/skills/chart-visualization/references/organization-chart.md
+++ b/skills/chart-visualization/references/organization-chart.md
@@ -1,0 +1,134 @@
+## 图表属性
+
+- 名称：组织架构图
+- 别名：组织结构图、机构图，英文名：Organization Chart、Organizational Chart
+- 形状：树形（从上到下层次布局）
+- 图表类别：关系图
+- 图表功能：展示组织内部的层级结构和部门关系
+
+## 基础概念
+
+组织架构图用于直观地展示组织内部的层级结构和部门关系。它通过节点和边表示不同的职位、部门及其上下级关系。每个节点代表一个职位或部门，边则表示上下级或平级关系。以树状结构呈现，顶层为最高管理层，逐层向下展开，直至各个部门和职位。
+
+支持为每个节点添加描述信息（如职位描述或部门简介），鼠标悬停时以 tooltip 形式展示详情。
+
+## 适用场景
+
+- 展示公司或团队的层级结构，明确各个职位和部门的上下级关系。
+- 展示员工的职位和部门分布。
+- 项目管理时，明确项目团队的成员和职责分工。
+- 用于股权穿透、投资上下游公司等依赖分析。
+
+## 不适用场景
+
+1. 展示具体的线性任务流程，更推荐使用流程图。
+2. 没有明确上下级关系的扁平化组织。
+3. 展示节点间非层级的复杂关联，更推荐使用网络图。
+
+## 图表用法
+
+### 图表属性
+
+```typescript
+type OrganizationChartData = {
+  name: string;
+  description?: string;
+  children?: OrganizationChartData[];
+};
+
+type OrganizationChart = {
+  type: 'organization-chart';
+   OrganizationChartData;
+  title?: string;
+  theme?: 'default' | 'dark' | 'academy';
+  style?: {
+    backgroundColor?: string;
+    palette?: string[];
+  };
+};
+```
+
+### 数据要求
+
+- type：图表的类型，必填，文本类型，值必须为 "organization-chart"。
+- data：图表的数据，必填，`OrganizationChartData` 对象类型，包含以下字段：
+  - name：节点的名称，表示职位或部门的名称，必须唯一，必填，字符串类型；
+  - description：节点的描述信息，可以包含职位职责或部门简介等，选填，字符串类型；
+  - children：子节点数组，表示下级职位或部门，选填，数组对象类型。如果当前节点没有子节点，该字段可以省略。每个子节点本身也是一个 `OrganizationChartData` 对象，可以递归构建多层次的树状结构；
+- title：图表标题，选填，文本类型。
+- theme：图表主题，选填，文本类型，可选值为 "default" | "dark" | "academy"，默认值为 "default"。
+- style：图表样式，选填，对象类型；
+  - palette：颜色映射，选填，数组类型，合法颜色值数组。
+  - backgroundColor：背景颜色，选填，文本类型，合法颜色值。
+
+## 使用示例
+
+1. 技术团队组织架构，包含首席技术官及其下属的软件工程和 IT 支持两个部门。
+
+```
+vis organization-chart
+data
+  name Alice Johnson
+  description Chief Technology Officer
+  children
+    - name Bob Smith
+      description Senior Software Engineer
+      children
+        - name Charlie Brown
+          description Software Engineer
+        - name Diana White
+          description Software Engineer
+    - name Eve Black
+      description IT Support Department Head
+      children
+        - name Frank Green
+          description IT Support Specialist
+        - name Grace Blue
+          description IT Support Specialist
+title 技术部组织架构
+```
+
+2. 公司高层管理架构，仅展示职位名称，不含描述，academy 主题。
+
+```
+vis organization-chart
+data
+  name 董事会
+  children
+    - name 首席执行官
+      children
+        - name 首席技术官
+        - name 首席财务官
+        - name 首席运营官
+    - name 监事会
+theme academy
+title 公司治理结构
+```
+
+3. 投资控股穿透结构，dark 主题，自定义配色。
+
+```
+vis organization-chart
+data
+  name 集团控股
+  description 母公司
+  children
+    - name 科技子公司
+      description 持股 80%
+      children
+        - name 研发中心
+          description 技术研发部门
+        - name 产品中心
+          description 产品开发部门
+    - name 金融子公司
+      description 持股 100%
+      children
+        - name 资产管理部
+          description 投资管理
+        - name 风控部
+          description 风险控制
+theme dark
+style
+  palette #5B8FF9 #61DDAA #65789B #F6BD16 #7262FD
+title 集团投资控股结构
+```


### PR DESCRIPTION
After the supplementary icons were added, there were still some missing skills and information on the homepage.
<img width="1264" height="970" alt="image" src="https://github.com/user-attachments/assets/fde5b258-7d89-45b4-92e1-ef0a3b07749f" />
