### PR TITLE
Normalize color palette handling for all chart types

### DIFF
--- a/site/app/examples/page.tsx
+++ b/site/app/examples/page.tsx
@@ -1985,7 +1985,7 @@ theme dark`,
         title: 'GDP 年度趋势面积图：展示 2013-2022 年 GDP 变化趋势，从 59.3 万亿增长至 121 万亿。',
         description:
           'GDP 年度趋势面积图：展示 2013-2022 年 GDP 变化趋势，从 59.3 万亿增长至 121 万亿。',
-        code: 'vis area\ndata\n  - time 2013\n    value 59.3\n  - time 2014\n    value 64.4\n  - time 2015\n    value 68.9\n  - time 2016\n    value 74.4\n  - time 2017\n    value 82.7\n  - time 2018\n    value 91.9\n  - time 2019\n    value 99.1\n  - time 2020\n    value 101.6\n  - time 2021\n    value 114.4\n  - time 2022\n    value 121\ntitle GDP年度趋势\naxisXTitle 年份\naxisYTitle GDP(万亿)',
+        code: 'vis area\ndata\n  - time 2013\n    value 59.3\n  - time 2014\n    value 64.4\n  - time 2015\n    value 68.9\n  - time 2016\n    value 74.4\n  - time 2017\n    value 82.7\n  - time 2018\n    value 91.9\n  - time 2019\n    value 99.1\n  - time 2020\n    value 101.6\n  - time 2021\n    value 114.4\n  - time 2022\n    value 121\ntitle GDP年度趋势\naxisXTitle 年份\naxisYTitle GDP(万亿)\nstyle\n  palette #FFB6C1',
       },
       {
         title:

--- a/src/util/theme.ts
+++ b/src/util/theme.ts
@@ -174,6 +174,6 @@ export const normalizePalette = (
   palette: string | string[] | undefined,
   theme: string,
 ): string[] => {
-  if (!palette) return getThemeColors(theme);
+  if (!palette || (Array.isArray(palette) && palette.length === 0)) return getThemeColors(theme);
   return Array.isArray(palette) ? palette : [palette];
 };

--- a/src/util/theme.ts
+++ b/src/util/theme.ts
@@ -165,3 +165,15 @@ export const getBackgroundColor = (theme: string): string => {
       return '#FFF';
   }
 };
+
+/**
+ * Normalize palette to always return an array.
+ * Handles the case where a single color is parsed as a string instead of an array.
+ */
+export const normalizePalette = (
+  palette: string | string[] | undefined,
+  theme: string,
+): string[] => {
+  if (!palette) return getThemeColors(theme);
+  return Array.isArray(palette) ? palette : [palette];
+};

--- a/src/vis/area/index.ts
+++ b/src/vis/area/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * AreaDataItem is the type for each data item in the area chart.
@@ -92,7 +92,7 @@ export const Area = (options: VisualizationOptions): AreaInstance => {
 
     const { lineWidth = 2 } = style;
     const hasGroupField = data.length > 0 && data[0]?.group !== undefined;
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
     const fillColor = getLinearGradientColor(colors[0] || DEFAULT_COLOR);
 

--- a/src/vis/bar/index.ts
+++ b/src/vis/bar/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * BarDataItem is the type for each data item in the bar chart.
@@ -88,7 +88,7 @@ export const Bar = (options: VisualizationOptions): BarInstance => {
     }
 
     const hasGroupField = data.length > 0 && data[0]?.group !== undefined;
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Create chart
@@ -128,7 +128,7 @@ export const Bar = (options: VisualizationOptions): BarInstance => {
     // Configure scale
     const scaleConfig: any = {
       y: { nice: true },
-      ...(style.palette?.length ? { color: { range: colors } } : {}),
+      ...(style.palette ? { color: { range: colors } } : {}),
     };
 
     // Configure chart options

--- a/src/vis/boxplot/index.ts
+++ b/src/vis/boxplot/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * BoxplotDataItem is the type for each data item in the boxplot chart.
@@ -78,7 +78,7 @@ export const Boxplot = (options: VisualizationOptions): BoxplotInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
     const startAtZero = style.startAtZero || false;
 

--- a/src/vis/column/index.ts
+++ b/src/vis/column/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * ColumnDataItem is the type for each data item in the column chart.
@@ -88,7 +88,7 @@ export const Column = (options: VisualizationOptions): ColumnInstance => {
     }
 
     const hasGroupField = data.length > 0 && data[0]?.group !== undefined;
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Create chart
@@ -128,7 +128,7 @@ export const Column = (options: VisualizationOptions): ColumnInstance => {
     // Configure scale
     const scaleConfig: any = {
       y: { nice: true },
-      ...(style.palette?.length ? { color: { range: colors } } : {}),
+      ...(style.palette ? { color: { range: colors } } : {}),
     };
 
     // Configure chart options

--- a/src/vis/dual-axes/index.ts
+++ b/src/vis/dual-axes/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * DualAxesSeriesItem defines a single series in the dual-axes chart.
@@ -98,7 +98,7 @@ export const DualAxes = (options: VisualizationOptions): DualAxesInstance => {
     }
 
     const { startAtZero = false } = style;
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Transform data

--- a/src/vis/flow-diagram/index.ts
+++ b/src/vis/flow-diagram/index.ts
@@ -1,6 +1,6 @@
 import { ExtensionCategory, Graph, HoverActivate, idOf, register, type NodeData } from '@antv/g6';
 import type { GraphData, VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors } from '../../util/theme';
+import { getBackgroundColor, normalizePalette } from '../../util/theme';
 
 /**
  * FlowDiagramConfig defines the configuration for rendering the flow diagram.
@@ -157,7 +157,7 @@ export const FlowDiagram = (options: VisualizationOptions): FlowDiagramInstance 
 
     ensureBehaviorRegistered();
 
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Resolve container element

--- a/src/vis/funnel/index.ts
+++ b/src/vis/funnel/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * FunnelDataItem is the type for each data item in the funnel chart.
@@ -73,7 +73,7 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Helper function to calculate conversion rate

--- a/src/vis/histogram/index.ts
+++ b/src/vis/histogram/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * HistogramConfig defines the configuration for rendering the histogram chart.
@@ -73,7 +73,7 @@ export const Histogram = (options: VisualizationOptions): HistogramInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Create chart

--- a/src/vis/indented-tree/index.ts
+++ b/src/vis/indented-tree/index.ts
@@ -13,7 +13,7 @@ import {
   treeToGraphData,
 } from '@antv/g6';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors } from '../../util/theme';
+import { getBackgroundColor, normalizePalette } from '../../util/theme';
 
 // ---------------------------------------------------------------------------
 // Official G6 indented-tree implementation (adapted for GPT-Vis)
@@ -328,8 +328,7 @@ export const IndentedTree = (options: VisualizationOptions): IndentedTreeInstanc
 
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
     const isDark = theme === 'dark';
-    const palette =
-      style.palette && style.palette.length > 0 ? style.palette : getThemeColors(theme);
+    const palette = normalizePalette(style.palette, theme);
 
     containerEl.style.background = backgroundColor;
     containerEl.style.borderRadius = '4px';

--- a/src/vis/line/index.ts
+++ b/src/vis/line/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * LineDataItem is the type for each data item in the line chart.
@@ -79,7 +79,7 @@ export const Line = (options: VisualizationOptions): LineInstance => {
 
     const { lineWidth = 2 } = style;
     const hasGroupField = data.length > 0 && data[0]?.group !== undefined;
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Create chart

--- a/src/vis/liquid/index.ts
+++ b/src/vis/liquid/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 // Default dimensions used for font size calculation when not explicitly provided
 const DEFAULT_WIDTH = 640;
@@ -66,7 +66,7 @@ export const Liquid = (options: VisualizationOptions): LiquidInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Calculate dynamic font size based on chart dimensions

--- a/src/vis/mindmap/index.ts
+++ b/src/vis/mindmap/index.ts
@@ -1,6 +1,6 @@
 import { Graph, idOf, positionOf, treeToGraphData } from '@antv/g6';
 import type { TreeGraphData, VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors } from '../../util/theme';
+import { getBackgroundColor, normalizePalette } from '../../util/theme';
 
 export type MindmapData = TreeGraphData;
 
@@ -132,8 +132,7 @@ export const Mindmap = (options: VisualizationOptions): MindmapInstance => {
 
     containerEl.innerHTML = '';
 
-    const colors =
-      style.palette && style.palette.length > 0 ? style.palette : getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
     const isDark = theme === 'dark';
 

--- a/src/vis/network-graph/index.ts
+++ b/src/vis/network-graph/index.ts
@@ -1,6 +1,6 @@
 import { Graph } from '@antv/g6';
 import type { GraphData, VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors } from '../../util/theme';
+import { getBackgroundColor, normalizePalette } from '../../util/theme';
 
 export type NetworkGraphNode = GraphData['nodes'][number];
 export type NetworkGraphEdge = GraphData['edges'][number];
@@ -86,8 +86,7 @@ export const NetworkGraph = (options: VisualizationOptions): NetworkGraphInstanc
       graph = null;
     }
 
-    const colors =
-      style.palette && style.palette.length > 0 ? style.palette : getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
     const isDark = theme === 'dark';
 

--- a/src/vis/organization-chart/index.ts
+++ b/src/vis/organization-chart/index.ts
@@ -1,6 +1,6 @@
 import { Graph } from '@antv/g6';
 import type { TreeGraphData, VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors } from '../../util/theme';
+import { getBackgroundColor, normalizePalette } from '../../util/theme';
 
 export type OrganizationChartData = TreeGraphData;
 
@@ -139,8 +139,7 @@ export const OrganizationChart = (options: VisualizationOptions): OrganizationCh
 
     containerEl.innerHTML = '';
 
-    const colors =
-      style.palette && style.palette.length > 0 ? style.palette : getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
     const isDark = theme === 'dark';
 

--- a/src/vis/pie/index.ts
+++ b/src/vis/pie/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * PieDataItem is the type for each data item in the pie chart.
@@ -76,7 +76,7 @@ export const Pie = (options: VisualizationOptions): PieInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Calculate sum for percentage labels

--- a/src/vis/radar/index.ts
+++ b/src/vis/radar/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * RadarDataItem is the type for each data item in the radar chart.
@@ -108,7 +108,7 @@ export const Radar = (options: VisualizationOptions): RadarInstance => {
     }
 
     const { lineWidth = 2 } = style;
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Transform data to parallel format

--- a/src/vis/sankey/index.ts
+++ b/src/vis/sankey/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * SankeyDataItem is the type for each data item in the sankey chart.
@@ -75,7 +75,7 @@ export const Sankey = (options: VisualizationOptions): SankeyInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Create chart

--- a/src/vis/scatter/index.ts
+++ b/src/vis/scatter/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * ScatterDataItem is the type for each data item in the scatter chart.
@@ -73,7 +73,7 @@ export const Scatter = (options: VisualizationOptions): ScatterInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Check if data has group field

--- a/src/vis/treemap/index.ts
+++ b/src/vis/treemap/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * TreemapDataItem is the type for each data item in the treemap chart.
@@ -87,7 +87,7 @@ export const Treemap = (options: VisualizationOptions): TreemapInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Create chart

--- a/src/vis/venn/index.ts
+++ b/src/vis/venn/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * VennDataItem is the type for each data item in the venn chart.
@@ -86,7 +86,7 @@ export const Venn = (options: VisualizationOptions): VennInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     const normalizedData = data.map((d) => ({

--- a/src/vis/violin/index.ts
+++ b/src/vis/violin/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * ViolinDataItem is the type for each data item in the violin chart.
@@ -78,7 +78,7 @@ export const Violin = (options: VisualizationOptions): ViolinInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
     const startAtZero = style.startAtZero || false;
 

--- a/src/vis/word-cloud/index.ts
+++ b/src/vis/word-cloud/index.ts
@@ -1,6 +1,6 @@
 import { Chart } from '@antv/g2';
 import type { VisualizationOptions } from '../../types';
-import { getBackgroundColor, getThemeColors, getThemeObject } from '../../util/theme';
+import { getBackgroundColor, getThemeObject, normalizePalette } from '../../util/theme';
 
 /**
  * WordCloudDataItem is the type for each data item in the word cloud chart.
@@ -72,7 +72,7 @@ export const WordCloud = (options: VisualizationOptions): WordCloudInstance => {
     }
 
     // Get colors from style.palette or theme defaults
-    const colors = style.palette || getThemeColors(theme);
+    const colors = normalizePalette(style.palette, theme);
     const backgroundColor = style.backgroundColor || getBackgroundColor(theme);
 
     // Create chart


### PR DESCRIPTION
### PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [ ] add / modify test cases
- [ ] documents, demos

修复问题，色板如果在只配置单颜色的情况下会因为通用的解析方案解析为 字符串而非数组，该行为符合style的整体逻辑，但是会导致图表在消费颜色时出现各种意外情况

### Screenshot

| Before | After |
| ------ | ----- |
| ❌   <img width="2772" height="1702" alt="image" src="https://github.com/user-attachments/assets/c87ad656-c008-429d-a877-c0186cfcb8b5" />| ✅    
<img width="2124" height="1346" alt="image" src="https://github.com/user-attachments/assets/c874b1cd-037e-4030-8449-71b78776fbd3" />|
