### PR TITLE
Refactor G6 chart dimensions and update SKILL.md documentation

### DIFF
--- a/site/app/examples/[chart]/page.tsx
+++ b/site/app/examples/[chart]/page.tsx
@@ -71,12 +71,7 @@ export default function ChartDocContent({ params }: { params: Promise<{ chart: s
                       </h4>
                     </div>
 
-                    <ChartPreview
-                      wrapper
-                      visSyntax={ex.code}
-                      chartId={`${chart}-${index}`}
-                      style={{ height: '552px' }}
-                    />
+                    <ChartPreview wrapper visSyntax={ex.code} chartId={`${chart}-${index}`} />
                   </div>
                 </div>
               ))}

--- a/site/app/examples/examplesData/area-chart.ts
+++ b/site/app/examples/examplesData/area-chart.ts
@@ -110,10 +110,10 @@ export const areaChartData = {
     },
     {
       title:
-        '用面积图可视化我的数据 [{ "year": 2015,"value": 7200.0 },{ "year": 2016, "value": 3660.0 },{ "year": 2017 ,"...',
+        '用面积图可视化 1974-1977 年 Gas flaring、Renewables、Fossil fuels 三类能源数据的变化趋势。',
       description:
-        '用面积图可视化我的数据 [{ "year": 2015,"value": 7200.0 },{ "year": 2016, "value": 3660.0 },{ "year": 2017 ,"...',
-      code: 'vis area\ndata\n  - time 2015\n    value 7200.0\n  - time 2016\n    value 3660.0\n  - time 2017\n    value 4100.0\naxisXTitle year\naxisYTitle value',
+        '用面积图可视化 1974-1977 年 Gas flaring、Renewables、Fossil fuels 三类能源数据的变化趋势。',
+      code: 'vis area\ndata\n  - time 1974\n    value 107\n    group "Gas flaring"\n  - time 1974\n    value 208\n    group Renewables\n  - time 1974\n    value 356\n    group "Fossil fuels"\n  - time 1975\n    value 173\n    group "Gas flaring"\n  - time 1975\n    value 415\n    group Renewables\n  - time 1975\n    value 364\n    group "Fossil fuels"\n  - time 1976\n    value 117\n    group "Gas flaring"\n  - time 1976\n    value 220\n    group Renewables\n  - time 1976\n    value 373\n    group "Fossil fuels"\n  - time 1977\n    value 122\n    group "Gas flaring"\n  - time 1977\n    value 225\n    group Renewables\n  - time 1977\n    value 382\n    group "Fossil fuels"\naxisXTitle Year\naxisYTitle Value',
     },
   ],
 };

--- a/site/app/examples/examplesData/bar-chart.ts
+++ b/site/app/examples/examplesData/bar-chart.ts
@@ -96,17 +96,17 @@ export const barChartData = {
   examples: [
     {
       title:
-        '海底捞公司外卖收入的变化，2015 年收入金额 80 百万元，2016 年收入金额 140 百万元，2017 年收入金额 220 百万元。用条形图可视化。',
+        '全球十大科技公司 2023 财年收入对比：亚马逊 5748 亿美元居首，苹果 3833 亿美元次之，Alphabet 3074 亿美元排第三。',
       description:
-        '海底捞公司外卖收入的变化，2015 年收入金额 80 百万元，2016 年收入金额 140 百万元，2017 年收入金额 220 百万元。用条形图可视化。',
-      code: 'vis bar\ndata\n  - category "2015 年"\n    value 80\n  - category "2016 年"\n    value 140\n  - category "2017 年"\n    value 220\ntitle 海底捞公司外卖收入\naxisXTitle 年份\naxisYTitle "金额 （百万元）"',
+        '全球十大科技公司 2023 财年收入对比：亚马逊 5748 亿美元居首，苹果 3833 亿美元次之，Alphabet 3074 亿美元排第三。',
+      code: 'vis bar\ndata\n  - category Microsoft\n    value 2119\n  - category Tencent\n    value 859\n  - category Apple\n    value 3833\n  - category TSMC\n    value 759\n  - category Amazon\n    value 5748\n  - category Huawei\n    value 1070\n  - category Alphabet\n    value 3074\n  - category Intel\n    value 542\n  - category Samsung\n    value 2080\n  - category Meta\n    value 1349\ntitle 全球十大科技公司2023财年收入\naxisXTitle 公司\naxisYTitle "收入（亿美元）"',
     },
     {
       title:
-        '用条形图可视化我的数据 [{ "name": "第一产业","industrial": 7200.0 },{ "name": "第二产业", "industrial": 36600.0 },{ ...',
+        '用条形图可视化我的数据 [{ "type": "1-3秒", "value": 0.16 }, { "type": "4-10秒", "value": 0.125 }, ...]',
       description:
-        '用条形图可视化我的数据 [{ "name": "第一产业","industrial": 7200.0 },{ "name": "第二产业", "industrial": 36600.0 },{ ...',
-      code: 'vis bar\ndata\n  - category 第一产业\n    value 7200.0\n  - category 第二产业\n    value 36600.0\n  - category 第三产业\n    value 41000.0\naxisXTitle name\naxisYTitle industrial',
+        '用条形图可视化我的数据 [{ "type": "1-3秒", "value": 0.16 }, { "type": "4-10秒", "value": 0.125 }, ...]',
+      code: 'vis bar\ndata\n  - category 1-3秒\n    value 0.16\n  - category 4-10秒\n    value 0.125\n  - category 11-30秒\n    value 0.24\n  - category 31-60秒\n    value 0.19\n  - category 1-3分\n    value 0.22\n  - category 3-10分\n    value 0.05\n  - category 10-30分\n    value 0.01\n  - category 30+分\n    value 0.015\naxisXTitle type\naxisYTitle value',
     },
     {
       title:

--- a/site/app/examples/examplesData/boxplot.ts
+++ b/site/app/examples/examplesData/boxplot.ts
@@ -60,24 +60,19 @@ export const boxplotData = {
             description: '图表样式，选填，对象类型；',
           },
           {
-            property: 'style.boxColor',
-            type: 'optional',
-            description: '盒体颜色，选填，文本类型，合法颜色值。',
-          },
-          {
-            property: 'style.whiskerColor',
-            type: 'optional',
-            description: '须线颜色，选填，文本类型，合法颜色值。',
-          },
-          {
-            property: 'style.outlierColor',
-            type: 'optional',
-            description: '异常值颜色，选填，文本类型，合法颜色值。',
-          },
-          {
             property: 'style.backgroundColor',
             type: 'optional',
             description: '背景颜色，选填，文本类型，合法颜色值。',
+          },
+          {
+            property: 'style.palette',
+            type: 'optional',
+            description: '自定义配色，选填，字符串数组类型。',
+          },
+          {
+            property: 'style.startAtZero',
+            type: 'optional',
+            description: 'Y轴是否从零开始，选填，布尔类型，默认值为 false。',
           },
         ],
       },
@@ -99,10 +94,10 @@ export const boxplotData = {
     },
     {
       title:
-        '企鹅体重分布（按种类分组）：Adelie、Chinstrap、Gentoo 三种企鹅体重（g）分布，自定义盒体和须线颜色。',
+        '企鹅体重分布（按种类分组）：Adelie、Chinstrap、Gentoo 三种企鹅体重（g）分布，自定义配色和背景色。',
       description:
-        '企鹅体重分布（按种类分组）：Adelie、Chinstrap、Gentoo 三种企鹅体重（g）分布，自定义盒体和须线颜色。',
-      code: 'vis boxplot\ndata\n  - category Adelie\n    value 3750\n  - category Adelie\n    value 3800\n  - category Adelie\n    value 3250\n  - category Adelie\n    value 3450\n  - category Adelie\n    value 3650\n  - category Adelie\n    value 3625\n  - category Adelie\n    value 4675\n  - category Adelie\n    value 3475\n  - category Adelie\n    value 4250\n  - category Adelie\n    value 3300\n  - category Adelie\n    value 3700\n  - category Adelie\n    value 3200\n  - category Chinstrap\n    value 3500\n  - category Chinstrap\n    value 3900\n  - category Chinstrap\n    value 3650\n  - category Chinstrap\n    value 3525\n  - category Chinstrap\n    value 3725\n  - category Chinstrap\n    value 3950\n  - category Chinstrap\n    value 3250\n  - category Chinstrap\n    value 3750\n  - category Chinstrap\n    value 4150\n  - category Chinstrap\n    value 3700\n  - category Chinstrap\n    value 3800\n  - category Gentoo\n    value 4950\n  - category Gentoo\n    value 5500\n  - category Gentoo\n    value 5700\n  - category Gentoo\n    value 4650\n  - category Gentoo\n    value 5550\n  - category Gentoo\n    value 4750\n  - category Gentoo\n    value 5200\n  - category Gentoo\n    value 5850\n  - category Gentoo\n    value 5050\n  - category Gentoo\n    value 5100\n  - category Gentoo\n    value 4800\ntitle 企鹅体重分布（按种类）\naxisYTitle 体重（g）\nstyle\n  boxColor #FF9800\n  whiskerColor #2196F3\n  backgroundColor #F5F5F5',
+        '企鹅体重分布（按种类分组）：Adelie、Chinstrap、Gentoo 三种企鹅体重（g）分布，自定义配色和背景色。',
+      code: 'vis boxplot\ndata\n  - category Adelie\n    value 3750\n  - category Adelie\n    value 3800\n  - category Adelie\n    value 3250\n  - category Adelie\n    value 3450\n  - category Adelie\n    value 3650\n  - category Adelie\n    value 3625\n  - category Adelie\n    value 4675\n  - category Adelie\n    value 3475\n  - category Adelie\n    value 4250\n  - category Adelie\n    value 3300\n  - category Adelie\n    value 3700\n  - category Adelie\n    value 3200\n  - category Chinstrap\n    value 3500\n  - category Chinstrap\n    value 3900\n  - category Chinstrap\n    value 3650\n  - category Chinstrap\n    value 3525\n  - category Chinstrap\n    value 3725\n  - category Chinstrap\n    value 3950\n  - category Chinstrap\n    value 3250\n  - category Chinstrap\n    value 3750\n  - category Chinstrap\n    value 4150\n  - category Chinstrap\n    value 3700\n  - category Chinstrap\n    value 3800\n  - category Gentoo\n    value 4950\n  - category Gentoo\n    value 5500\n  - category Gentoo\n    value 5700\n  - category Gentoo\n    value 4650\n  - category Gentoo\n    value 5550\n  - category Gentoo\n    value 4750\n  - category Gentoo\n    value 5200\n  - category Gentoo\n    value 5850\n  - category Gentoo\n    value 5050\n  - category Gentoo\n    value 5100\n  - category Gentoo\n    value 4800\ntitle 企鹅体重分布（按种类）\naxisYTitle 体重（g）\nstyle\n  palette ["#FF9800", "#2196F3", "#4CAF50"]\n  backgroundColor #F5F5F5',
     },
   ],
 };

--- a/site/app/examples/examplesData/column-chart.ts
+++ b/site/app/examples/examplesData/column-chart.ts
@@ -97,17 +97,17 @@ export const columnChartData = {
   examples: [
     {
       title:
-        '海底捞公司外卖收入的变化，2015 年收入金额 80 百万元，2016 年收入金额 140 百万元，2017 年收入金额 220 百万元。用柱形图可视化。',
+        '全球十大科技公司 2023 财年收入对比：亚马逊 5748 亿美元居首，苹果 3833 亿美元次之，Alphabet 3074 亿美元排第三。',
       description:
-        '海底捞公司外卖收入的变化，2015 年收入金额 80 百万元，2016 年收入金额 140 百万元，2017 年收入金额 220 百万元。用柱形图可视化。',
-      code: 'vis column\ndata\n  - category "2015 年"\n    value 80\n  - category "2016 年"\n    value 140\n  - category "2017 年"\n    value 220\ntitle 海底捞公司外卖收入\naxisXTitle 年份\naxisYTitle "金额 （百万元）"',
+        '全球十大科技公司 2023 财年收入对比：亚马逊 5748 亿美元居首，苹果 3833 亿美元次之，Alphabet 3074 亿美元排第三。',
+      code: 'vis column\ndata\n  - category Microsoft\n    value 2119\n  - category Tencent\n    value 859\n  - category Apple\n    value 3833\n  - category TSMC\n    value 759\n  - category Amazon\n    value 5748\n  - category Huawei\n    value 1070\n  - category Alphabet\n    value 3074\n  - category Intel\n    value 542\n  - category Samsung\n    value 2080\n  - category Meta\n    value 1349\ntitle 全球十大科技公司2023财年收入\naxisXTitle 公司\naxisYTitle "收入（亿美元）"',
     },
     {
       title:
-        '用柱形图可视化我的数据 [{ "title": "第一产业","industrial": 7200.0 },{ "title": "第二产业", "industrial": 36600.0 },...',
+        '用柱形图可视化我的数据 [{ "type": "1-3秒", "value": 0.16 }, { "type": "4-10秒", "value": 0.125 }, ...]',
       description:
-        '用柱形图可视化我的数据 [{ "title": "第一产业","industrial": 7200.0 },{ "title": "第二产业", "industrial": 36600.0 },...',
-      code: 'vis column\ndata\n  - category 第一产业\n    value 7200.0\n  - category 第二产业\n    value 36600.0\n  - category 第三产业\n    value 41000.0\naxisXTitle title\naxisYTitle industrial',
+        '用柱形图可视化我的数据 [{ "type": "1-3秒", "value": 0.16 }, { "type": "4-10秒", "value": 0.125 }, ...]',
+      code: 'vis column\ndata\n  - category 1-3秒\n    value 0.16\n  - category 4-10秒\n    value 0.125\n  - category 11-30秒\n    value 0.24\n  - category 31-60秒\n    value 0.19\n  - category 1-3分\n    value 0.22\n  - category 3-10分\n    value 0.05\n  - category 10-30分\n    value 0.01\n  - category 30+分\n    value 0.015\naxisXTitle type\naxisYTitle value',
     },
     {
       title:

--- a/site/app/examples/examplesData/line-chart.ts
+++ b/site/app/examples/examplesData/line-chart.ts
@@ -90,25 +90,24 @@ export const lineChartData = {
   },
   examples: [
     {
-      title:
-        '我国出生人口，2015 年出生人口 1655 万人，2016 年出生人口 1786 万人，2017 年出生人口 1723 万人。用折线图可视化。',
+      title: 'GDP 年度趋势折线图：展示 2013-2022 年 GDP 变化趋势，从 59.3 万亿增长至 121 万亿。',
       description:
-        '我国出生人口，2015 年出生人口 1655 万人，2016 年出生人口 1786 万人，2017 年出生人口 1723 万人。用折线图可视化。',
-      code: 'vis line\ndata\n  - time "2015 年"\n    value 1655\n  - time "2016 年"\n    value 1786\n  - time "2017 年"\n    value 1723\ntitle 出生人口变化\naxisXTitle 年份\naxisYTitle 出生人口（万人）',
+        'GDP 年度趋势折线图：展示 2013-2022 年 GDP 变化趋势，从 59.3 万亿增长至 121 万亿。',
+      code: 'vis line\ndata\n  - time 2013\n    value 59.3\n  - time 2014\n    value 64.4\n  - time 2015\n    value 68.9\n  - time 2016\n    value 74.4\n  - time 2017\n    value 82.7\n  - time 2018\n    value 91.9\n  - time 2019\n    value 99.1\n  - time 2020\n    value 101.6\n  - time 2021\n    value 114.4\n  - time 2022\n    value 121\ntitle GDP年度趋势\naxisXTitle 年份\naxisYTitle GDP(万亿)',
     },
     {
       title:
-        '我国出生人口与死亡人口，2015 年分别是 1655 万人与 975 万人，2016 年分别是出生人口 1786 万人与 977 万人，2017 年分别是出生人口 1723 万人与 986 万人...',
+        '2019 年到 2023 年中三个城市的空气污染指数变化：北京分别为 150，160，145，155，165；广州分别为 100，110，105，115，120；上海分别为 9...',
       description:
-        '我国出生人口与死亡人口，2015 年分别是 1655 万人与 975 万人，2016 年分别是出生人口 1786 万人与 977 万人，2017 年分别是出生人口 1723 万人与 986 万人。',
-      code: 'vis line\ndata\n  - time "2015 年"\n    value 1655\n    group 出生人口\n  - time "2015 年"\n    value 975\n    group 死亡人口\n  - time "2016 年"\n    value 1786\n    group 出生人口\n  - time "2016 年"\n    value 977\n    group 死亡人口\n  - time "2017 年"\n    value 1723\n    group 出生人口\n  - time "2017 年"\n    value 986\n    group 死亡人口\ntitle 出生人口与死亡人口变化\naxisXTitle 年份\naxisYTitle 人口（万人）',
+        '2019 年到 2023 年中三个城市的空气污染指数变化：北京分别为 150，160，145，155，165；广州分别为 100，110，105，115，120；上海分别为 9...',
+      code: 'vis line\ndata\n  - time 2019年\n    value 150\n    group 北京\n  - time 2020年\n    value 160\n    group 北京\n  - time 2021年\n    value 145\n    group 北京\n  - time 2022年\n    value 155\n    group 北京\n  - time 2023年\n    value 165\n    group 北京\n  - time 2019年\n    value 100\n    group 广州\n  - time 2020年\n    value 110\n    group 广州\n  - time 2021年\n    value 105\n    group 广州\n  - time 2022年\n    value 115\n    group 广州\n  - time 2023年\n    value 120\n    group 广州\n  - time 2019年\n    value 90\n    group 上海\n  - time 2020年\n    value 85\n    group 上海\n  - time 2021年\n    value 80\n    group 上海\n  - time 2022年\n    value 75\n    group 上海\n  - time 2023年\n    value 70\n    group 上海\ntitle 城市空气污染指数变化\naxisXTitle 年份\naxisYTitle 空气污染指数',
     },
     {
       title:
-        '用折线图可视化我的数据 [{ "year": 2015,"industrial": 7200.0 },{ "year": 2016, "industrial": 3660.0 },{ "year...',
+        '用折线图可视化 1974-1977 年 Gas flaring、Renewables、Fossil fuels 三类能源数据的变化趋势。',
       description:
-        '用折线图可视化我的数据 [{ "year": 2015,"industrial": 7200.0 },{ "year": 2016, "industrial": 3660.0 },{ "year...',
-      code: 'vis line\ndata\n  - time 2015\n    value 7200.0\n  - time 2016\n    value 3660.0\n  - time 2017\n    value 4100.0\naxisXTitle year\naxisYTitle industrial',
+        '用折线图可视化 1974-1977 年 Gas flaring、Renewables、Fossil fuels 三类能源数据的变化趋势。',
+      code: 'vis line\ndata\n  - time 1974\n    value 107\n    group "Gas flaring"\n  - time 1974\n    value 208\n    group Renewables\n  - time 1974\n    value 356\n    group "Fossil fuels"\n  - time 1975\n    value 173\n    group "Gas flaring"\n  - time 1975\n    value 415\n    group Renewables\n  - time 1975\n    value 364\n    group "Fossil fuels"\n  - time 1976\n    value 117\n    group "Gas flaring"\n  - time 1976\n    value 220\n    group Renewables\n  - time 1976\n    value 373\n    group "Fossil fuels"\n  - time 1977\n    value 122\n    group "Gas flaring"\n  - time 1977\n    value 225\n    group Renewables\n  - time 1977\n    value 382\n    group "Fossil fuels"\naxisXTitle Year\naxisYTitle Value',
     },
   ],
 };

--- a/skills/chart-visualization/SKILL.md
+++ b/skills/chart-visualization/SKILL.md
@@ -106,19 +106,64 @@ categories
   - 2021
 ```
 
+**注意字符串数组中的字符串不要带有空格**：
+✅
+
+```
+data
+  - 1月
+  - 2月
+  - 3月
+```
+
+❌
+
+```
+data
+  - 1 月
+  - 2 月
+  - 3 月
+```
+
 **5. 嵌套对象** — 对象名占一行，子属性缩进：
 
 ```typescript
-{ style?: { backgroundColor?: string; palette?: string[] } }
+{ style?: { backgroundColor?: string; boxColor?: string } }
 ```
 
 ```
 style
   backgroundColor #f0f2f5
-  palette #5B8FF9 #61DDAA #65789B
+  boxColor #5B8FF9
 ```
 
-注意：`palette` 是颜色数组，在 syntax 中用空格分隔写在同一行。
+```typescript
+{ series: { data: number[]; axisYTitle?: string }[] }
+```
+
+```
+series
+  - axisYTitle 销售额
+    data
+      - 91.9
+      - 99.1
+  - axisYTitle 利润率
+    data
+      - 0.055
+      - 0.06
+```
+
+**注意：`style.palette` 是颜色数组，需要特殊处理，其他的严格按照通用规则**：
+在 syntax 中用空格分隔写在同一行：
+
+```typescript
+{ style?: { palette?: string[]; } }
+```
+
+```
+style
+  palette #5B8FF9 #61DDAA #65789B
+```
 
 **6. 递归树形结构** — 根节点属性直接写，`children` 数组用 `- ` 缩进：
 
@@ -139,36 +184,7 @@ data
     - name 子节点B
 ```
 
-**7. 图数据（nodes + edges）** — 分别列出：
-
-```typescript
-{ data: { nodes: { name: string }[]; edges: { source: string; target: string; name?: string }[] } }
-```
-
-```
-data
-  nodes
-    - name 节点A
-    - name 节点B
-  edges
-    - source 节点A
-      target 节点B
-      name 关系
-```
-
-**8. 数值空格数组** — series 中的 `data: number[]` 用空格分隔写在同一行：
-
-```typescript
-{ series: { type: string; data: number[] }[] }
-```
-
-```
-series
-  - type column
-    data 500 600 700
-```
-
-**9. `vis` 前缀** — 语法第一行必须是 `vis [type]`：
+**7. `vis` 前缀** — 语法第一行必须是 `vis [type]`：
 
 ```
 vis line
@@ -195,7 +211,7 @@ const config: Column = {
   title: '产品销量对比',
   axisXTitle: '产品',
   axisYTitle: '销量（万）',
-  isStack: true,
+  stack: true,
   theme: 'academy',
   style: {
     palette: ['#5B8FF9', '#61DDAA'],
@@ -236,7 +252,6 @@ style
 ### HTML
 
 ```html
-<!DOCTYPE html>
 <html>
   <head>
     <script src="https://unpkg.com/@antv/gpt-vis/dist/umd/index.min.js"></script>
@@ -412,6 +427,7 @@ type Column = {
   axisXTitle?: string;
   axisYTitle?: string;
   stack?: boolean;
+  group?: boolean;
   theme?: 'default' | 'dark' | 'academy';
   style?: {
     backgroundColor?: string;
@@ -500,10 +516,13 @@ type Boxplot = {
   type: 'boxplot';
   data: { category: string; value: number }[];
   title?: string;
+  axisXTitle?: string;
+  axisYTitle?: string;
   theme?: 'default' | 'dark' | 'academy';
   style?: {
     backgroundColor?: string;
     palette?: string[];
+    startAtZero?: boolean;
   };
 };
 ```
@@ -547,10 +566,15 @@ type Waterfall = {
   type: 'waterfall';
   data: { category: string; value: number }[];
   title?: string;
+  axisXTitle?: string;
+  axisYTitle?: string;
   theme?: 'default' | 'dark' | 'academy';
   style?: {
-    palette?: { positiveColor?: string; negativeColor?: string; totalColor?: string };
-    palette?: string[];
+    palette?: {
+      positiveColor?: string;
+      negativeColor?: string;
+      totalColor?: string;
+    };
   };
 };
 ```
@@ -595,7 +619,11 @@ type WordCloud = {
 ```typescript
 type Venn = {
   type: 'venn';
-  data: { sets: string | string[]; value: number; label?: string }[];
+  data: {
+    sets: string | string[]; // 交集用逗号分隔，如 "A,B"
+    value: number;
+    label?: string; // 集合的显示名称，用于显示图表上对应集合的名称
+  }[];
   title?: string;
   theme?: 'default' | 'dark' | 'academy';
   style?: {
@@ -772,35 +800,74 @@ type Table = {
 
 #### 实体类型
 
-| 类型                 | 说明                            | 示例                                                      |
-| -------------------- | ------------------------------- | --------------------------------------------------------- |
-| `metric_name`        | 指标名称，通常是主语            | `[销售额](metric_name)`                                   |
-| `metric_value`       | 指标值，表示具体数值            | `[¥150万](metric_value, origin=1500000)`                  |
-| `other_metric_value` | 次要指标值                      | `[平均: ¥120](other_metric_value)`                        |
-| `dim_name`           | 维度名称                        | `[省份](dim_name)`                                        |
-| `dim_value`          | 维度值                          | `[北京](dim_value)`                                       |
-| `time_desc`          | 时间描述                        | `[2024年Q3](time_desc)`                                   |
-| `trend_desc`         | 趋势描述                        | `[上升](trend_desc)`                                      |
-| `delta_value`        | 绝对变化值                      | `[+1200](delta_value)`                                    |
-| `delta_value_pos`    | 正向绝对变化值（需 abs 处理）   | `[3000](delta_value_pos)`                                 |
-| `delta_value_neg`    | 负向绝对变化值（需 abs 处理）   | `[500](delta_value_neg)`                                  |
-| `ratio_value`        | 百分比变化值                    | `[+15%](ratio_value, origin=0.15, assessment="positive")` |
-| `ratio_value_pos`    | 正向百分比变化值（需 abs 处理） | `[15.3%](ratio_value_pos, origin=0.153)`                  |
-| `ratio_value_neg`    | 负向百分比变化值（需 abs 处理） | `[8.2%](ratio_value_neg, origin=0.082)`                   |
-| `contribute_ratio`   | 贡献占比                        | `[45%](contribute_ratio, origin=0.45)`                    |
-| `proportion`         | 比例占比                        | `[22%](proportion)`                                       |
+| 类型                 | 说明                           | 支持属性               | 示例                                                                             |
+| -------------------- | ------------------------------ | ---------------------- | -------------------------------------------------------------------------------- |
+| `metric_name`        | 指标名称                       | —                      | `[日活跃用户数](metric_name)`                                                    |
+| `metric_value`       | 指标数值，支持格式化和原始数据 | `origin`, `unit`       | `[¥1,234,567](metric_value, origin=1234567)`                                     |
+| `other_metric_value` | 次要/辅助指标值                | —                      | `[平均订单价值](other_metric_value)`                                             |
+| `delta_value`        | 绝对变化值，带正负评估         | `origin`, `assessment` | `[¥180,000](delta_value, origin=180000, assessment="positive")`                  |
+| `ratio_value`        | 百分比变化/增长率              | `origin`, `assessment` | `[15%](ratio_value, origin=0.15, assessment="positive")`                         |
+| `contribute_ratio`   | 部分对整体的贡献占比           | `origin`, `assessment` | `[64.8%](contribute_ratio, origin=0.648, assessment="positive")`                 |
+| `proportion`         | 部分与整体的比率               | `origin`               | `[四分之三](proportion, origin=0.75)`                                            |
+| `trend_desc`         | 趋势的定性描述                 | `assessment`           | `[强劲增长](trend_desc, assessment="positive")`                                  |
+| `dim_value`          | 维度值（类别、地区、产品等）   | —                      | `[亚太地区](dim_value)`                                                          |
+| `time_desc`          | 时间引用和时间段描述           | —                      | `[2024年Q4](time_desc)`                                                          |
+| `rank`               | 排名位置                       | `detail`               | `[排名第一](rank, detail=[320, 180, 90, 65, 45])`                                |
+| `difference`         | 值之间的差距或差异             | `detail`               | `[1.4亿台的差距](difference, detail=[200, 180, 160, 140])`                       |
+| `anomaly`            | 数据中的异常模式或离群值       | `detail`               | `[异常集中](anomaly, detail=[15, 18, 20, 65, 22])`                               |
+| `association`        | 变量之间的相关性或关系         | `detail`               | `[强相关性](association, detail=[{"x":100,"y":105},{"x":120,"y":128}])`          |
+| `distribution`       | 数据分布                       | `detail`               | `[分布](distribution, detail=[15, 25, 35, 15, 10])`                              |
+| `seasonality`        | 周期性/季节性模式              | `detail`               | `[明显季节性](seasonality, detail={"data":[80, 90, 95, 135], "range":[0, 150]})` |
 
-元数据字段：`origin`（原始数值）、`assessment`（`"positive"` / `"negative"` / `"equal"`）、`unit`（单位）
+属性字段：`origin`（原始数值）、`assessment`（`"positive"` / `"negative"` / `"equal"`）、`unit`（单位）、`detail`（用于高级分析实体的数据）
+
+**示例一：销售报告**
 
 ```
 # Q4 销售报告
 
-[2024年Q4](time_desc)，[销售额](metric_name)达到[¥523万](metric_value, origin=5230000)，
-较上季度[增长15.2%](ratio_value, origin=0.152, assessment="positive")。
+## 概述
 
-## 关键指标
-- [新客户数](metric_name)：[1,234](metric_value, origin=1234)
-- [客户留存率](metric_name)：[89.5%](ratio_value, origin=0.895)
+在 [2024年Q4](time_desc)，[总收入](metric_name)达到
+[¥520万](metric_value, origin=5200000)，相比Q3增长了
+[¥80万](delta_value, origin=800000, assessment="positive")，
+增长率为 [18%](ratio_value, origin=0.18, assessment="positive")。
+[客单价](other_metric_value)为 [¥328](metric_value, origin=328)。
+
+## 各地区表现
+
+[北美地区](dim_value)以 [¥210万](metric_value, origin=2100000)领先，
+占总收入的 [40%](contribute_ratio, origin=0.40, assessment="positive")。
+该地区在所有市场中[排名第一](rank, detail=[2100000, 1800000, 1300000])。
+
+[欧洲](dim_value)呈现[强劲势头](trend_desc, assessment="positive")，
+[近一半](proportion, origin=0.48)的销售额来自新客户。
+与北美的[90万差距](difference, detail=[210, 195, 180, 170])正在逐季缩小。
+```
+
+**示例二：数据分析报告**
+
+```
+# 用户行为分析报告
+
+## 流量趋势
+
+[2024年](time_desc)，[月活跃用户](metric_name)达到
+[1,200万](metric_value, origin=12000000)，同比增长
+[22%](ratio_value, origin=0.22, assessment="positive")，整体呈现
+[持续上升](trend_desc, assessment="positive")趋势。
+
+## 用户分布
+
+用户年龄[分布](distribution, detail=[5, 15, 35, 30, 15])集中在25-35岁区间。
+[一线城市](dim_value)用户呈现[明显季节性](seasonality, detail={"data":[80, 95, 110, 150], "range":[0, 200]})，
+每年Q4达到峰值。
+
+## 异常与关联
+
+[华南地区](dim_value)出现[异常流量集中](anomaly, detail=[12, 15, 14, 58, 16])，
+需进一步排查。分析发现用户活跃度与推送频次之间存在
+[强正相关](association, detail=[{"x":1,"y":20},{"x":3,"y":55},{"x":5,"y":90}])。
 ```
 
 ## 最佳实践

--- a/skills/chart-visualization/SKILL.md
+++ b/skills/chart-visualization/SKILL.md
@@ -128,13 +128,13 @@ data
 **5. 嵌套对象** — 对象名占一行，子属性缩进：
 
 ```typescript
-{ style?: { backgroundColor?: string; boxColor?: string } }
+{ style?: { backgroundColor?: string; positiveColor?: string } }
 ```
 
 ```
 style
   backgroundColor #f0f2f5
-  boxColor #5B8FF9
+  positiveColor #5B8FF9
 ```
 
 ```typescript
@@ -153,7 +153,7 @@ series
       - 0.06
 ```
 
-**注意：`style.palette` 是颜色数组，需要特殊处理，其他的严格按照通用规则**：
+**注意：当 `style.palette` 是颜色数组时，需要特殊处理，其他的数组情况严格按照通用规则**：
 在 syntax 中用空格分隔写在同一行：
 
 ```typescript
@@ -509,12 +509,12 @@ type Histogram = {
 
 ### 箱线图(boxplot) / 小提琴图(violin)
 
-数据结构相同，需要同一 category 有多条数据以展示分布。
+数据结构相同，需要同一 category 有多条数据以展示分布。支持按 `group` 字段分组展示。
 
 ```typescript
 type Boxplot = {
-  type: 'boxplot';
-  data: { category: string; value: number }[];
+  type: 'boxplot' | 'violin';
+  data: { category: string; value: number; group?: string }[];
   title?: string;
   axisXTitle?: string;
   axisYTitle?: string;

--- a/skills/chart-visualization/SKILL.md
+++ b/skills/chart-visualization/SKILL.md
@@ -153,8 +153,7 @@ series
       - 0.06
 ```
 
-**注意：当 `style.palette` 是颜色数组时，需要特殊处理，其他的数组情况严格按照通用规则**：
-在 syntax 中用空格分隔写在同一行：
+**注意：当 `style.palette` 是颜色数组时，需要特殊处理，其他的数组情况严格按照通用规则**：在 syntax 中用空格分隔写在同一行。
 
 ```typescript
 { style?: { palette?: string[]; } }

--- a/src/vis/fishbone-diagram/index.ts
+++ b/src/vis/fishbone-diagram/index.ts
@@ -134,16 +134,13 @@ export const FishboneDiagram = (options: VisualizationOptions): FishboneDiagramI
 
     containerEl.style.backgroundColor = backgroundColor;
 
-    const graphWidth = containerEl.offsetWidth || width || 600;
-    const graphHeight = containerEl.offsetHeight || height || 400;
-
     const graphData = convertData(data);
     assignBranchColors(graphData, palette);
 
     graph = new Graph({
       container: containerEl,
-      width: graphWidth,
-      height: graphHeight,
+      width,
+      height,
       autoFit: 'view',
       padding: 20,
       theme: chartTheme,

--- a/src/vis/fishbone-diagram/index.ts
+++ b/src/vis/fishbone-diagram/index.ts
@@ -142,6 +142,7 @@ export const FishboneDiagram = (options: VisualizationOptions): FishboneDiagramI
       width,
       height,
       autoFit: 'view',
+      autoResize: true,
       padding: 20,
       theme: chartTheme,
       plugins: title

--- a/src/vis/flow-diagram/index.ts
+++ b/src/vis/flow-diagram/index.ts
@@ -231,6 +231,7 @@ export const FlowDiagram = (options: VisualizationOptions): FlowDiagramInstance 
       theme,
       data: { nodes: g6Nodes, edges: g6Edges },
       autoFit: 'view',
+      autoResize: true,
       padding: 20,
       plugins: title
         ? [{ key: 'title', type: 'title', title, titleFill: isDark ? '#e0e6ed' : '#1a1a2e' }]

--- a/src/vis/indented-tree/index.ts
+++ b/src/vis/indented-tree/index.ts
@@ -334,9 +334,6 @@ export const IndentedTree = (options: VisualizationOptions): IndentedTreeInstanc
     containerEl.style.borderRadius = '4px';
     containerEl.style.overflow = 'hidden';
 
-    const graphHeight = containerEl.offsetHeight || height || 400;
-    const graphWidth = containerEl.offsetWidth || width || 600;
-
     ensureIconfontInjected();
     ensureExtensionsRegistered();
 
@@ -346,8 +343,8 @@ export const IndentedTree = (options: VisualizationOptions): IndentedTreeInstanc
     graph = new Graph({
       container: containerEl,
       x: 60,
-      width: graphWidth,
-      height: graphHeight,
+      width,
+      height,
       autoFit: 'view',
       padding: 20,
       data: graphData,

--- a/src/vis/indented-tree/index.ts
+++ b/src/vis/indented-tree/index.ts
@@ -346,6 +346,7 @@ export const IndentedTree = (options: VisualizationOptions): IndentedTreeInstanc
       width,
       height,
       autoFit: 'view',
+      autoResize: true,
       padding: 20,
       data: graphData,
       node: {

--- a/src/vis/mindmap/index.ts
+++ b/src/vis/mindmap/index.ts
@@ -138,9 +138,6 @@ export const Mindmap = (options: VisualizationOptions): MindmapInstance => {
 
     containerEl.style.background = backgroundColor;
 
-    const graphWidth = containerEl.offsetWidth || width || 600;
-    const graphHeight = containerEl.offsetHeight || height || 400;
-
     // Convert tree data and assign branch colors before rendering
     const graphData = convertTreeData(data);
     assignBranchColors(graphData, colors);
@@ -156,8 +153,8 @@ export const Mindmap = (options: VisualizationOptions): MindmapInstance => {
 
     graph = new Graph({
       container: containerEl,
-      width: graphWidth,
-      height: graphHeight,
+      width,
+      height,
       autoFit: 'view',
       autoResize: true,
       padding: 20,

--- a/src/vis/network-graph/index.ts
+++ b/src/vis/network-graph/index.ts
@@ -105,9 +105,6 @@ export const NetworkGraph = (options: VisualizationOptions): NetworkGraphInstanc
     containerEl.style.borderRadius = '4px';
     containerEl.style.overflow = 'hidden';
 
-    const graphHeight = containerEl.offsetHeight || height || 400;
-    const graphWidth = containerEl.offsetWidth || width || 600;
-
     // Build G6 node data
     const nodeData = nodes.map((node, index) => ({
       id: node.name,
@@ -157,7 +154,6 @@ export const NetworkGraph = (options: VisualizationOptions): NetworkGraphInstanc
       },
       circular: {
         type: 'circular',
-        radius: Math.min(graphWidth, graphHeight) * 0.35,
       },
       grid: {
         type: 'grid',
@@ -165,7 +161,6 @@ export const NetworkGraph = (options: VisualizationOptions): NetworkGraphInstanc
       },
       radial: {
         type: 'radial',
-        unitRadius: Math.min(graphWidth, graphHeight) * 0.2,
         preventOverlap: true,
         nodeSize: 32,
       },
@@ -186,8 +181,8 @@ export const NetworkGraph = (options: VisualizationOptions): NetworkGraphInstanc
     // (see runtime/graph.ts render() method), so autoFit: 'view' is safe here.
     graph = new Graph({
       container: containerEl,
-      width: graphWidth,
-      height: graphHeight,
+      width,
+      height,
       autoFit: 'view',
       padding: 24,
       data: {

--- a/src/vis/network-graph/index.ts
+++ b/src/vis/network-graph/index.ts
@@ -184,6 +184,7 @@ export const NetworkGraph = (options: VisualizationOptions): NetworkGraphInstanc
       width,
       height,
       autoFit: 'view',
+      autoResize: true,
       padding: 24,
       data: {
         nodes: nodeData,

--- a/src/vis/organization-chart/index.ts
+++ b/src/vis/organization-chart/index.ts
@@ -173,6 +173,7 @@ export const OrganizationChart = (options: VisualizationOptions): OrganizationCh
       width,
       height,
       autoFit: 'view',
+      autoResize: true,
       padding: 24,
       data: { nodes: nodeData, edges: edgeData },
       plugins: [

--- a/src/vis/organization-chart/index.ts
+++ b/src/vis/organization-chart/index.ts
@@ -147,9 +147,6 @@ export const OrganizationChart = (options: VisualizationOptions): OrganizationCh
     containerEl.style.borderRadius = '4px';
     containerEl.style.overflow = 'hidden';
 
-    const graphHeight = containerEl.offsetHeight || height || 400;
-    const graphWidth = containerEl.offsetWidth || width || 600;
-
     // Flatten tree structure into G6 flat nodes + edges
     const flatNodes: FlatNode[] = [];
     const flatEdges: Array<{ source: string; target: string }> = [];
@@ -173,8 +170,8 @@ export const OrganizationChart = (options: VisualizationOptions): OrganizationCh
 
     graph = new Graph({
       container: containerEl,
-      width: graphWidth,
-      height: graphHeight,
+      width,
+      height,
       autoFit: 'view',
       padding: 24,
       data: { nodes: nodeData, edges: edgeData },


### PR DESCRIPTION
主要两点改动：
1. 部分G6图表存在的问题，不会使用给定的高度和宽度，也不会自适应容器宽高，会走到默认值，修复了该问题
2. skill 优化调整，优化后：claude-sonnet 、GLM、Kimi、MinMax、Qwen 等模型都可以正确根据skill来输出26种图表的html
3. 感觉部分示例不是很美观，换了点数据

高度问题修复前：
<img width="2074" height="1330" alt="image" src="https://github.com/user-attachments/assets/43a95aca-2f94-4e22-a845-281c65588f8d" />

高度问题修复后：
<img width="2154" height="1340" alt="image" src="https://github.com/user-attachments/assets/dd1d009d-8de1-4f80-9d63-af961afd6eb8" />

skill验证：
- [x] 不同模型验证
- [ ] React、vue效果验证 
- [ ] 匹配度验证优化