### PR TITLE
deps(gpt-vis-ssr): add @antv/g as devDependency and use type-only import

### DIFF
--- a/bindings/gpt-vis-ssr/package.json
+++ b/bindings/gpt-vis-ssr/package.json
@@ -29,6 +29,7 @@
     "test": "jest --config ./jest.config.ts"
   },
   "dependencies": {
+    "@antv/g": "^6.3.1",
     "@antv/g-plugin-rough-canvas-renderer": "^2.0.44",
     "@antv/g2-ssr": "^0.2.0",
     "@antv/g6-ssr": "^0.1.0",
@@ -37,7 +38,6 @@
     "canvas": "^3"
   },
   "devDependencies": {
-    "@antv/g": "^6.3.1",
     "@blazediff/core": "^1.8.0",
     "@types/jest": "^29.5.14",
     "@types/pngjs": "^6.0.5",

--- a/bindings/gpt-vis-ssr/package.json
+++ b/bindings/gpt-vis-ssr/package.json
@@ -37,6 +37,7 @@
     "canvas": "^3"
   },
   "devDependencies": {
+    "@antv/g": "^6.3.1",
     "@blazediff/core": "^1.8.0",
     "@types/jest": "^29.5.14",
     "@types/pngjs": "^6.0.5",

--- a/bindings/gpt-vis-ssr/src/vis/types.ts
+++ b/bindings/gpt-vis-ssr/src/vis/types.ts
@@ -1,4 +1,4 @@
-import { RendererPlugin } from '@antv/g';
+import type { RendererPlugin } from '@antv/g';
 
 export type CommonOptions = {
   width?: number;

--- a/site/app/components/Carousel/index.tsx
+++ b/site/app/components/Carousel/index.tsx
@@ -54,7 +54,10 @@ function Row({
   }, [measure]);
 
   return (
-    <div className={`relative overflow-x-clip w-auto ${className ?? ''}`} style={{ perspective: '1200px' }}>
+    <div
+      className={`relative overflow-x-clip w-auto ${className ?? ''}`}
+      style={{ perspective: '1200px' }}
+    >
       <div
         ref={trackRef}
         className="flex w-max will-change-transform"
@@ -70,8 +73,18 @@ function Row({
           } as React.CSSProperties
         }
       >
-        <CarouselItems isLazy={isLazy} charts={charts} idPrefix="a" rotationOffset={rotationOffset} />
-        <CarouselItems isLazy={isLazy} charts={charts} idPrefix="b" rotationOffset={rotationOffset} />
+        <CarouselItems
+          isLazy={isLazy}
+          charts={charts}
+          idPrefix="a"
+          rotationOffset={rotationOffset}
+        />
+        <CarouselItems
+          isLazy={isLazy}
+          charts={charts}
+          idPrefix="b"
+          rotationOffset={rotationOffset}
+        />
       </div>
     </div>
   );
@@ -177,7 +190,14 @@ export function Carousel({ className }: { className?: string }) {
       onMouseLeave={() => setIsHovered(false)}
     >
       <Row charts={row1} shouldPlay={playing} isLazy={isLazy} rotationOffset={0} />
-      <Row charts={row2} shouldPlay={playing} isLazy={isLazy} offset className="hidden md:block" rotationOffset={3} />
+      <Row
+        charts={row2}
+        shouldPlay={playing}
+        isLazy={isLazy}
+        offset
+        className="hidden md:block"
+        rotationOffset={3}
+      />
     </div>
   );
 }


### PR DESCRIPTION
build 失败：
https://github.com/antvis/GPT-Vis/actions/runs/24982274277/job/73147066300

原因是使用 pnpm build，不支持幽灵依赖，所以导致了找不到包，失败了

本地之前使用 install dependencies from package 使用的npm所以不会有这个问题，看了一下 `package.json` 里面还声明了 :
```
  "engines": {
    "node": ">=18",
    "pnpm": ">=8"
  },
```
所以还是依然保留了使用pnpm来安装依赖和构建，估计之前本地发布都是使用到了 npm 安装的依赖就没出现这个问题。

修改后build成功，引入消费成功：
<img width="1126" height="595" alt="image" src="https://github.com/user-attachments/assets/20a83ceb-cc97-4eb4-88da-7a73167cb56c" />
