### PR TITLE
feat(radar): hide redundant axis lines and labels when align is enabled

### DIFF
--- a/bindings/gpt-vis-ssr/src/vis/radar.ts
+++ b/bindings/gpt-vis-ssr/src/vis/radar.ts
@@ -136,13 +136,21 @@ export async function Radar(options: RadarOptions) {
             zIndex: 1,
             titleFontSize: 10,
             titleSpacing: 8,
-            label: true,
-            labelFill: theme === 'dark' ? '#fff' : '#000',
-            labelOpacity: 0.45,
-            labelFontSize: 10,
-            line: true,
-            lineFill: '#000',
-            lineStrokeOpacity: 0.25,
+            label: align ? i === 0 : true,
+            ...(align && i !== 0
+              ? {}
+              : {
+                  labelFill: theme === 'dark' ? '#fff' : '#000',
+                  labelOpacity: 0.45,
+                  labelFontSize: 10,
+                }),
+            line: align ? i === 0 : true,
+            ...(align && i !== 0
+              ? {}
+              : {
+                  lineFill: '#000',
+                  lineStrokeOpacity: 0.25,
+                }),
             tickFilter: (_: string, idx: number) => {
               return !(i !== 0 && idx === 0);
             },

--- a/bindings/gpt-vis-ssr/src/vis/radar.ts
+++ b/bindings/gpt-vis-ssr/src/vis/radar.ts
@@ -137,20 +137,12 @@ export async function Radar(options: RadarOptions) {
             titleFontSize: 10,
             titleSpacing: 8,
             label: align ? i === 0 : true,
-            ...(align && i !== 0
-              ? {}
-              : {
-                  labelFill: theme === 'dark' ? '#fff' : '#000',
-                  labelOpacity: 0.45,
-                  labelFontSize: 10,
-                }),
+            labelFill: theme === 'dark' ? '#fff' : '#000',
+            labelOpacity: 0.45,
+            labelFontSize: 10,
             line: align ? i === 0 : true,
-            ...(align && i !== 0
-              ? {}
-              : {
-                  lineFill: '#000',
-                  lineStrokeOpacity: 0.25,
-                }),
+            lineFill: '#000',
+            lineStrokeOpacity: 0.25,
             tickFilter: (_: string, idx: number) => {
               return !(i !== 0 && idx === 0);
             },

--- a/src/vis/radar/index.ts
+++ b/src/vis/radar/index.ts
@@ -161,20 +161,12 @@ export const Radar = (options: VisualizationOptions): RadarInstance => {
             titleFontSize: 10,
             titleSpacing: 8,
             label: align ? i === 0 : true,
-            ...(align && i !== 0
-              ? {}
-              : {
-                  labelFill: theme === 'dark' ? '#fff' : '#000',
-                  labelOpacity: 0.45,
-                  labelFontSize: 10,
-                }),
+            labelFill: theme === 'dark' ? '#fff' : '#000',
+            labelOpacity: 0.45,
+            labelFontSize: 10,
             line: align ? i === 0 : true,
-            ...(align && i !== 0
-              ? {}
-              : {
-                  lineFill: '#000',
-                  lineStrokeOpacity: 0.25,
-                }),
+            lineFill: '#000',
+            lineStrokeOpacity: 0.25,
             tickFilter: (_: string, idx: number) => {
               return !(i !== 0 && idx === 0);
             },

--- a/src/vis/radar/index.ts
+++ b/src/vis/radar/index.ts
@@ -160,13 +160,21 @@ export const Radar = (options: VisualizationOptions): RadarInstance => {
             zIndex: 1,
             titleFontSize: 10,
             titleSpacing: 8,
-            label: true,
-            labelFill: theme === 'dark' ? '#fff' : '#000',
-            labelOpacity: 0.45,
-            labelFontSize: 10,
-            line: true,
-            lineFill: '#000',
-            lineStrokeOpacity: 0.25,
+            label: align ? i === 0 : true,
+            ...(align && i !== 0
+              ? {}
+              : {
+                  labelFill: theme === 'dark' ? '#fff' : '#000',
+                  labelOpacity: 0.45,
+                  labelFontSize: 10,
+                }),
+            line: align ? i === 0 : true,
+            ...(align && i !== 0
+              ? {}
+              : {
+                  lineFill: '#000',
+                  lineStrokeOpacity: 0.25,
+                }),
             tickFilter: (_: string, idx: number) => {
               return !(i !== 0 && idx === 0);
             },


### PR DESCRIPTION
ssr包的效果，可见右边：
<img width="2650" height="1344" alt="image" src="https://github.com/user-attachments/assets/16e580ba-bcbd-437a-9fd2-afdb23bc7cba" />

普通包的效果：
<img width="1990" height="1246" alt="image" src="https://github.com/user-attachments/assets/e3f9cfe7-d5c3-4f28-ad8c-58825687b682" />
