### PR TITLE
fix: add overflow stroke to funnel labels

### DIFF
--- a/bindings/gpt-vis-ssr/src/vis/funnel.ts
+++ b/bindings/gpt-vis-ssr/src/vis/funnel.ts
@@ -83,7 +83,7 @@ export async function Funnel(options: FunnelOptions) {
           {
             text: (d: any) => `${d.category}\n${d.value}`,
             position: 'inside',
-            transform: [{ type: 'contrastReverse', palette: ['#000', '#666'] }],
+            transform: [{ type: 'contrastReverse' }, { type: 'overflowStroke' }],
             ...(texture === 'rough' ? { fontFamily: FontFamily.ROUGH } : {}),
           },
           {

--- a/src/vis/funnel/index.ts
+++ b/src/vis/funnel/index.ts
@@ -126,7 +126,14 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
             {
               text: (d: any) => `${d.category}\n${d.value}`,
               position: 'inside',
-              transform: [{ type: 'contrastReverse', palette: ['#000', '#666'] }],
+              transform: [
+                {
+                  type: 'contrastReverse',
+                },
+                {
+                  type: 'overflowStroke',
+                },
+              ],
             },
             // Connecting line for conversion rate
             {

--- a/src/vis/funnel/index.ts
+++ b/src/vis/funnel/index.ts
@@ -126,14 +126,7 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
             {
               text: (d: any) => `${d.category}\n${d.value}`,
               position: 'inside',
-              transform: [
-                {
-                  type: 'contrastReverse',
-                },
-                {
-                  type: 'overflowStroke',
-                },
-              ],
+              transform: [{ type: 'contrastReverse' }, { type: 'overflowStroke' }],
             },
             // Connecting line for conversion rate
             {


### PR DESCRIPTION
修改后不同主题效果图：
<img width="1944" height="1124" alt="image" src="https://github.com/user-attachments/assets/655904ee-9cd1-4add-9906-348e07deb764" />
<img width="1888" height="1058" alt="image" src="https://github.com/user-attachments/assets/bbd3a7c3-37ab-4710-996a-b4754f2e1309" />

ssr版本：
<img width="1800" height="1200" alt="image" src="https://github.com/user-attachments/assets/3e6bf211-d3c8-4961-be4e-a7c7105bb6e2" />
<img width="1800" height="1200" alt="image" src="https://github.com/user-attachments/assets/0ba7532f-0683-4fbd-85b8-07b375164c1a" />
