### PR TITLE
docs: add skill install section to homepage

### DIFF
--- a/site/app/docs/page.tsx
+++ b/site/app/docs/page.tsx
@@ -584,6 +584,24 @@ data
                       code="npx skills add https://github.com/antvis/GPT-Vis"
                     />
                   </div>
+                  <div className="mb-6">
+                    <p className="text-sm font-semibold text-on-surface mb-2">
+                      Manual Installation
+                    </p>
+                    <p className="text-on-surface-variant mb-4">
+                      If you prefer to install the skill manually, open the skill directory on
+                      GitHub, download it, and install it into your agent&apos;s local skills
+                      folder.
+                    </p>
+                    <a
+                      href="https://github.com/antvis/GPT-Vis/tree/ai/skills/chart-visualization"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex text-[#691eff] font-medium hover:underline"
+                    >
+                      Download chart-visualization skill from GitHub →
+                    </a>
+                  </div>
                   <div className="flex flex-col gap-4">
                     <p className="text-sm font-semibold text-on-surface">Usage Examples</p>
                     {[

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -81,6 +81,37 @@ gptVis.render(visSyntax);`}
         </div>
       </section>
 
+      {/* Skill Install Section */}
+      <section className="py-16 px-6 bg-gradient-to-br from-[#691eff]/5 via-white to-gray-50">
+        <div className="max-w-4xl mx-auto flex flex-col gap-8 items-center text-center">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-widest text-[#691eff] mb-3">
+              AI Agent Skill
+            </p>
+            <h2 className="text-3xl font-bold mb-4 text-gray-900">
+              Install the chart visualization skill
+            </h2>
+            <p className="text-lg text-gray-600">
+              Add GPT-Vis chart recommendation and syntax generation capabilities to your AI agent
+              workflow with one command.
+            </p>
+            <Link
+              href="/docs#skill"
+              className="mt-4 inline-flex text-[#691eff] font-medium hover:underline"
+            >
+              Read the skill documentation →
+            </Link>
+          </div>
+          <div className="w-full max-w-2xl">
+            <CodeBlock
+              code="npx skills add https://github.com/antvis/GPT-Vis"
+              lang="bash"
+              label="Install Skill"
+            />
+          </div>
+        </div>
+      </section>
+
       {/* Chart Types Section */}
       <section className="py-20 px-6 relative">
         <div className="absolute inset-0 -z-10 bg-gradient-to-br from-[#691eff]/5 to-transparent"></div>


### PR DESCRIPTION
## Summary
- Add a homepage section for installing the GPT-Vis chart visualization skill.
- Include a link from the homepage section to the skill documentation.
- Add a manual installation path in the docs that links to the `chart-visualization` skill directory on the `ai` branch.
- Use a light gradient background and compact vertical layout to match the homepage section rhythm.

## Validation
- `npm run lint`
- Checked the homepage and docs skill section with Chrome DevTools MCP.
- Verified the manual install link points to `https://github.com/antvis/GPT-Vis/tree/ai/skills/chart-visualization`.

## Screenshots
Homepage skill install section:

![Homepage skill install section](https://raw.githubusercontent.com/q32757468/GPT-Vis/pr-assets/docs-homepage-skill-install/pr-assets/docs-homepage-skill-install/home-skill-install-section.png)

Docs manual installation section:

![Docs manual installation section](https://raw.githubusercontent.com/q32757468/GPT-Vis/pr-assets/docs-homepage-skill-install/pr-assets/docs-homepage-skill-install/docs-skill-manual-install.png)
