### PR TITLE
docs: update shadcn install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Copy GPT-Vis React components directly into your project via shadcn CLI — full
 The universal `GPTVis` component accepts vis syntax strings or config objects for all 26 chart types:
 
 ```bash
-npx shadcn@latest add https://gpt-vis.antv.vision/r/gpt-vis.json
+npx shadcn@latest add @gpt-vis/gpt-vis
 ```
 
 ```tsx
@@ -425,7 +425,7 @@ title Sales Trend"
 Each chart type has its own component with a typed `config` prop — JSON only, chart-specific TypeScript validation:
 
 ```bash
-npx shadcn@latest add https://gpt-vis.antv.vision/r/line.json
+npx shadcn@latest add @gpt-vis/line
 ```
 
 ```tsx
@@ -448,9 +448,9 @@ import { Line } from '@/components/ui/line';
 All 26 chart types are available. Install any by name:
 
 ```bash
-npx shadcn@latest add https://gpt-vis.antv.vision/r/pie.json
-npx shadcn@latest add https://gpt-vis.antv.vision/r/bar.json
-npx shadcn@latest add https://gpt-vis.antv.vision/r/mindmap.json
+npx shadcn@latest add @gpt-vis/pie
+npx shadcn@latest add @gpt-vis/bar
+npx shadcn@latest add @gpt-vis/mindmap
 # ...and more
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -400,7 +400,7 @@ document.getElementById('content').innerHTML = marked.parse(markdown);
 通用的 `GPTVis` 组件，支持全部 26 种图表类型的 vis 语法字符串或 JSON 配置对象：
 
 ```bash
-npx shadcn@latest add https://gpt-vis.antv.vision/r/gpt-vis.json
+npx shadcn@latest add @gpt-vis/gpt-vis
 ```
 
 ```tsx
@@ -425,7 +425,7 @@ title 销售趋势"
 每种图表类型都有独立的组件，提供类型安全的 `config` 属性 — 仅支持 JSON，带 TypeScript 类型校验：
 
 ```bash
-npx shadcn@latest add https://gpt-vis.antv.vision/r/line.json
+npx shadcn@latest add @gpt-vis/line
 ```
 
 ```tsx
@@ -448,9 +448,9 @@ import { Line } from '@/components/ui/line';
 全部 26 种图表类型均可用，按名称安装即可：
 
 ```bash
-npx shadcn@latest add https://gpt-vis.antv.vision/r/pie.json
-npx shadcn@latest add https://gpt-vis.antv.vision/r/bar.json
-npx shadcn@latest add https://gpt-vis.antv.vision/r/mindmap.json
+npx shadcn@latest add @gpt-vis/pie
+npx shadcn@latest add @gpt-vis/bar
+npx shadcn@latest add @gpt-vis/mindmap
 # ...等等
 ```
 

--- a/site/app/docs/page.tsx
+++ b/site/app/docs/page.tsx
@@ -874,7 +874,7 @@ onUnmounted(() => gptVis?.destroy());
             <CodeBlock
               label="bash"
               lang="bash"
-              code="npx shadcn@latest add https://gpt-vis.antv.vision/r/gpt-vis.json"
+              code="npx shadcn@latest add @gpt-vis/gpt-vis"
             />
             <p className="text-on-surface-variant mt-4 mb-4">
               This copies the component into{' '}
@@ -953,7 +953,7 @@ export default function MyChart() {
             <CodeBlock
               label="bash"
               lang="bash"
-              code="npx shadcn@latest add https://gpt-vis.antv.vision/r/line.json"
+              code="npx shadcn@latest add @gpt-vis/line"
             />
             <p className="text-on-surface-variant mt-4 mb-2">
               This installs both <code className="text-indigo-600">line.tsx</code> and{' '}
@@ -1018,10 +1018,7 @@ export default function MyChart() {
 
             <h4 className="text-xl font-bold text-on-surface mt-6 mb-4">All 26 Chart Types</h4>
             <p className="text-on-surface-variant mb-4">
-              Install URL pattern:{' '}
-              <code className="text-indigo-600">
-                https://gpt-vis.antv.vision/r/&lt;type&gt;.json
-              </code>
+              Install name pattern: <code className="text-indigo-600">@gpt-vis/&lt;type&gt;</code>
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               {[


### PR DESCRIPTION
## Summary

- update shadcn install commands from registry URLs to `@gpt-vis/*` shorthand
- update the docs site install name pattern copy
- keep README and Chinese README examples aligned with the site

## Validation

- `npm run lint` in `site` (passes with existing `import/no-anonymous-default-export` warning in `site/app/components/Carousel/data.ts`)

<img width="783" height="327" alt="image" src="https://github.com/user-attachments/assets/462ad749-a3e9-49b6-9d7f-60d399719ca0" />

