### PR TITLE
Feat 0623

### DIFF
--- a/site/app/components/TopBar.tsx
+++ b/site/app/components/TopBar.tsx
@@ -27,7 +27,7 @@ export function TopBar() {
               onClick={() => setMobileMenuOpen(false)}
             >
               <Image
-                src="/gpt-vis-logo.png"
+                src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*BfsJQJp-dDwAAAAAQEAAAAgAemJ7AQ/original"
                 alt="GPT-Vis Logo"
                 width={52}
                 height={52}

--- a/site/app/docs/components/SideBar.tsx
+++ b/site/app/docs/components/SideBar.tsx
@@ -37,6 +37,7 @@ const tocItems = [
       { title: 'Markdown Integration', id: 'markdown-integration' },
       { title: 'Framework Integration', id: 'framework' },
       { title: 'Shadcn/ui Distribution', id: 'shadcn' },
+      { title: 'Ecosystem', id: 'ecosystem' },
     ],
   },
 ];

--- a/site/app/docs/page.tsx
+++ b/site/app/docs/page.tsx
@@ -871,11 +871,7 @@ onUnmounted(() => gptVis?.destroy());
             </p>
 
             <h4 className="text-xl font-bold text-on-surface mb-4">Installing</h4>
-            <CodeBlock
-              label="bash"
-              lang="bash"
-              code="npx shadcn@latest add @gpt-vis/gpt-vis"
-            />
+            <CodeBlock label="bash" lang="bash" code="npx shadcn@latest add @gpt-vis/gpt-vis" />
             <p className="text-on-surface-variant mt-4 mb-4">
               This copies the component into{' '}
               <code className="text-indigo-600">src/components/ui/gpt-vis.tsx</code>.
@@ -950,11 +946,7 @@ export default function MyChart() {
             <p className="text-on-surface-variant mb-4">
               Install any chart component by name. The base component is automatically included:
             </p>
-            <CodeBlock
-              label="bash"
-              lang="bash"
-              code="npx shadcn@latest add @gpt-vis/line"
-            />
+            <CodeBlock label="bash" lang="bash" code="npx shadcn@latest add @gpt-vis/line" />
             <p className="text-on-surface-variant mt-4 mb-2">
               This installs both <code className="text-indigo-600">line.tsx</code> and{' '}
               <code className="text-indigo-600">gpt-vis.tsx</code> into{' '}
@@ -1057,6 +1049,78 @@ export default function MyChart() {
                   <span className="text-on-surface-variant text-sm ml-2">{c.desc}</span>
                 </div>
               ))}
+            </div>
+          </section>
+
+          <section className="mb-10 scroll-mt-24" id="ecosystem">
+            <SectionHeading id="ecosystem">Ecosystem</SectionHeading>
+            <p className="text-on-surface-variant leading-relaxed mb-8">
+              We are continuously expanding the GPT-Vis ecosystem. From editor integrations and
+              framework bindings to AI toolchains and beyond—whatever you can imagine can be part of
+              it. We welcome community contributors to bring new ideas and projects, and help us
+              grow the map together.
+            </p>
+
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-outline-variant">
+                    <th className="text-left py-3 px-4 font-semibold text-on-surface">Package</th>
+                    <th className="text-left py-3 px-4 font-semibold text-on-surface">Ecosystem</th>
+                    <th className="text-left py-3 px-4 font-semibold text-on-surface">
+                      Description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-outline-variant">
+                  {[
+                    {
+                      name: 'rehype-gpt-vis',
+                      ecosystem: 'Unified / rehype',
+                      desc: 'For unified ecosystem (react-markdown, MDX, etc.)',
+                    },
+                    {
+                      name: 'markdown-it-gpt-vis',
+                      ecosystem: 'markdown-it',
+                      desc: 'For markdown-it (Vitepress, VuePress, etc.)',
+                    },
+                    {
+                      name: 'marked-gpt-vis',
+                      ecosystem: 'Marked',
+                      desc: 'For Marked (Hexo, GitBook, etc.)',
+                    },
+                  ].map((pkg) => (
+                    <tr key={pkg.name} className="hover:bg-surface-container transition-colors">
+                      <td className="py-3 px-4">
+                        <a
+                          href={`https://www.npmjs.com/package/${pkg.name}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:underline font-mono"
+                        >
+                          {pkg.name}
+                        </a>
+                      </td>
+                      <td className="py-3 px-4 text-on-surface-variant">{pkg.ecosystem}</td>
+                      <td className="py-3 px-4 text-on-surface-variant">{pkg.desc}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="mt-8 flex items-center gap-4">
+              <span className="text-on-surface-variant text-sm">
+                Have a plugin or integration?{' '}
+                <a
+                  href="https://github.com/antvis/GPT-Vis/issues"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Share it with us →
+                </a>
+              </span>
             </div>
           </section>
         </div>

--- a/skills/chart-visualization/SKILL.md
+++ b/skills/chart-visualization/SKILL.md
@@ -252,7 +252,7 @@ data
 
 - 语言标记固定为 `GPT-Vis`
 - 内容区使用 [Syntax 格式](#语法模式syntax-格式)规则编写，**首行必须包含 `vis <chart-type>`**（完整列表见上方[支持的图表类型](#支持的图表类型)）
-- 代码块会被 Markdown 插件转换为 `<code classname='language-gpt-vis'>`，由浏览器端渲染
+- 代码块会被 Markdown 插件转换为 <code class="language-gpt-vis">，由浏览器端渲染
 
 > **注意**：Markdown 模式下，内容区**必须**写首行 `vis <type>`，与纯 Syntax 模式格式一致。
 

--- a/skills/chart-visualization/SKILL.md
+++ b/skills/chart-visualization/SKILL.md
@@ -227,6 +227,35 @@ style
     - #61DDAA
 ```
 
+### Markdown 语法
+
+当输出为 Markdown 格式时，使用 `GPT-Vis` 作为 fenced code block 的语言标记，内容区写入完整的 [Syntax 格式](#语法模式syntax-格式)：
+
+````markdown
+```GPT-Vis
+vis line
+data
+  - time 2020
+    value 100
+```
+````
+
+**格式：**
+
+````
+```GPT-Vis
+<完整的 Syntax 内容，首行 vis <chart-type>>
+```
+````
+
+**语法规则：**
+
+- 语言标记固定为 `GPT-Vis`
+- 内容区使用 [Syntax 格式](#语法模式syntax-格式)规则编写，**首行必须包含 `vis <chart-type>`**（完整列表见上方[支持的图表类型](#支持的图表类型)）
+- 代码块会被 Markdown 插件转换为 `<code classname='language-gpt-vis'>`，由浏览器端渲染
+
+> **注意**：Markdown 模式下，内容区**必须**写首行 `vis <type>`，与纯 Syntax 模式格式一致。
+
 ## 代码模式
 
 根据目标框架生成完整可运行代码。


### PR DESCRIPTION
新增 Ecosystem 模块到文档站点
展示 GPT-Vis 的插件生态（rehype / markdown-it /  Marked）

<img width="1440" height="828" alt="image" src="https://github.com/user-attachments/assets/28c8c48a-5b3a-484d-a8cb-1754767cfba9" />
