### PR TITLE
fix(funnel): make conversion rate label configurable

### DIFF
--- a/bindings/gpt-vis-ssr/src/vis/funnel.ts
+++ b/bindings/gpt-vis-ssr/src/vis/funnel.ts
@@ -25,6 +25,12 @@ export type FunnelOptions = CommonOptions & {
    */
   data: FunnelDatum[];
   /**
+   * Label text for the conversion rate annotation.
+   * Defaults to 'Conversion Rate'. Override to localize
+   * (for example, '转化率' for Chinese).
+   */
+  conversionRateLabel?: string;
+  /**
    * The custom style for the funnel chart.
    */
   style?: FunnelStyle;
@@ -39,8 +45,15 @@ export async function Funnel(options: FunnelOptions) {
     theme = 'default',
     renderPlugins,
     style = {},
+    conversionRateLabel = 'Conversion Rate',
   } = options;
   const { backgroundColor, palette, texture = 'default' } = style;
+
+  // estimate label width and spacing
+  const conversionRateLabelWidth = conversionRateLabel.length * 7; // ~7px/char estimate
+  const conversionRateValueGap = 8; // extra gap between label and percentage
+  const paddingRightVal = Math.max(68, conversionRateLabelWidth + 100);
+
   const r = (start: any, end: any) => `${((end / start) * 100).toFixed(2)} %`;
 
   return await createChart({
@@ -52,7 +65,7 @@ export async function Funnel(options: FunnelOptions) {
     theme: THEME_MAP[theme],
     title: getTitle(title, texture),
     paddingLeft: 40,
-    paddingRight: 68,
+    paddingRight: paddingRightVal,
     children: [
       {
         type: 'interval',
@@ -100,7 +113,7 @@ export async function Funnel(options: FunnelOptions) {
             ...(texture === 'rough' ? { fontFamily: FontFamily.ROUGH } : {}),
           },
           {
-            text: (d: any, i: any) => (i !== 0 ? '转化率' : ''),
+            text: (d: any, i: any) => (i !== 0 ? conversionRateLabel : ''),
             position: 'top-right',
             textAlign: 'left',
             textBaseline: 'middle',
@@ -114,7 +127,7 @@ export async function Funnel(options: FunnelOptions) {
             position: 'top-right',
             textAlign: 'left',
             textBaseline: 'middle',
-            dx: 80,
+            dx: 40 + conversionRateLabelWidth + conversionRateValueGap,
             ...(texture === 'rough' ? { fontFamily: FontFamily.ROUGH } : {}),
           },
         ],
@@ -141,7 +154,7 @@ export async function Funnel(options: FunnelOptions) {
         },
         labels: [
           {
-            text: '转化率',
+            text: conversionRateLabel,
             position: 'left',
             textAlign: 'start',
             textBaseline: 'middle',
@@ -153,7 +166,7 @@ export async function Funnel(options: FunnelOptions) {
             text: r(data[0].value, data[data.length - 1].value),
             position: 'left',
             textAlign: 'start',
-            dx: 50,
+            dx: 10 + conversionRateLabelWidth + conversionRateValueGap,
             fill: '#000',
             ...(texture === 'rough' ? { fontFamily: FontFamily.ROUGH } : {}),
           },

--- a/src/vis/funnel/index.ts
+++ b/src/vis/funnel/index.ts
@@ -68,6 +68,11 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
   const render = (config: FunnelConfig): void => {
     const { data = [], theme = chartTheme, title, style = {}, conversionRateLabel = 'Conversion Rate' } = config;
 
+    // Estimate label width (px) and spacing to avoid overlap for longer labels like English
+    const conversionRateLabelWidth = conversionRateLabel.length * 7; // ~7px/char estimate
+    const conversionRateValueGap = 8; // extra gap between label and percentage
+    const paddingRightVal = Math.max(68, conversionRateLabelWidth + 100);
+
     // Clean up previous chart if exists
     if (chart) {
       chart.destroy();
@@ -87,7 +92,7 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
       height,
       autoFit: true,
       paddingLeft: 40,
-      paddingRight: 68,
+      paddingRight: paddingRightVal,
     });
 
     // Configure chart options
@@ -151,14 +156,14 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
               fill: '#666',
               dx: 40,
             },
-            // Conversion rate percentage
+            // Conversion rate percentage (dx computed to avoid overlap)
             {
               text: (d: any, i: any, dataArray: any) =>
                 i !== 0 ? conversionRate(dataArray[i - 1].value, dataArray[i].value) : '',
               position: 'top-right',
               textAlign: 'left',
               textBaseline: 'middle',
-              dx: 80,
+              dx: 40 + conversionRateLabelWidth + conversionRateValueGap,
             },
           ],
           viewStyle: {
@@ -198,7 +203,7 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
               text: conversionRate(data[0]?.value, data[data.length - 1]?.value),
               position: 'left',
               textAlign: 'start',
-              dx: 50,
+              dx: 10 + conversionRateLabelWidth + conversionRateValueGap,
               fill: '#000',
             },
           ],

--- a/src/vis/funnel/index.ts
+++ b/src/vis/funnel/index.ts
@@ -18,6 +18,7 @@ export interface FunnelConfig {
   data: FunnelDataItem[];
   theme?: 'default' | 'academy' | 'dark';
   title?: string;
+  conversionRateLabel?: string;
   style?: {
     backgroundColor?: string;
     palette?: string[];
@@ -65,7 +66,7 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
    * Render the funnel chart with the given configuration.
    */
   const render = (config: FunnelConfig): void => {
-    const { data = [], theme = chartTheme, title, style = {} } = config;
+    const { data = [], theme = chartTheme, title, style = {}, conversionRateLabel = 'Conversion Rate' } = config;
 
     // Clean up previous chart if exists
     if (chart) {
@@ -141,9 +142,9 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
               dx: 35,
               dy: -8,
             },
-            // Conversion rate label text
+            // Conversion rate label text (configurable)
             {
-              text: (d: any, i: any) => (i !== 0 ? '转化率' : ''),
+              text: (d: any, i: any) => (i !== 0 ? conversionRateLabel : ''),
               position: 'top-right',
               textAlign: 'left',
               textBaseline: 'middle',
@@ -186,7 +187,7 @@ export const Funnel = (options: VisualizationOptions): FunnelInstance => {
           },
           labels: [
             {
-              text: '转化率',
+              text: conversionRateLabel,
               position: 'left',
               textAlign: 'start',
               textBaseline: 'middle',


### PR DESCRIPTION
## PR includes

- [x] fixed #427
- [x] documents, demos

## Summary

This PR fixes hardcoded Chinese conversion-rate labels in the funnel chart renderer.

Previously, the funnel chart rendered `转化率` directly in the chart output, causing Chinese text to appear regardless of the user's language or locale.

This PR adds a configurable `conversionRateLabel` option with an English default:

```ts
conversionRateLabel?: string;
Default behavior now renders:
Conversion Rate 85.06 %
Users can still localize the label manually:
{
  type: 'funnel',
  conversionRateLabel: '转化率',
  data: [...]
}
Changes
Added conversionRateLabel?: string to browser-side FunnelConfig.
Added conversionRateLabel?: string to SSR-side FunnelOptions.
Replaced hardcoded 转化率 labels in:src/vis/funnel/index.ts
bindings/gpt-vis-ssr/src/vis/funnel.ts

Added dynamic spacing for conversion-rate percentage labels to avoid overlap with longer labels like Conversion Rate.
Added dynamic paddingRight to reduce clipping risk for longer labels.
Verification
Confirmed no hardcoded 转化率 remains in funnel renderer output logic.
Confirmed default label is now Conversion Rate.
Confirmed custom label override remains possible via conversionRateLabel.
Browser and SSR funnel renderers were both updated.