### PR TITLE
feat: add unified annotation system 

### DIFF
--- a/__tests__/annotation.test.ts
+++ b/__tests__/annotation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { compileCartesianAnnotations } from '../src/annotation/cartesian';
+import { normalizeAnnotations } from '../src/annotation/normalize';
+import { getAnnotationTheme } from '../src/annotation/theme';
+
+const data = [
+  { time: 'Q1', value: 80, group: 'North' },
+  { time: 'Q2', value: 120, group: 'North' },
+  { time: 'Q2', value: 145, group: 'South' },
+];
+
+const context = {
+  data,
+  getX: (datum: (typeof data)[number]) => datum.time,
+  getY: (datum: (typeof data)[number]) => datum.value,
+  getSeries: (datum: (typeof data)[number]) => datum.group,
+  theme: getAnnotationTheme('default'),
+};
+
+describe('normalizeAnnotations', () => {
+  it('keeps valid annotations and skips hidden annotations', () => {
+    const result = normalizeAnnotations([
+      { type: 'reference-line', channel: 'y', value: 100 },
+      { type: 'reference-line', channel: 'y', value: 120, visible: false },
+    ]);
+
+    expect(result.annotations).toHaveLength(1);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('rejects invalid numeric bands', () => {
+    const result = normalizeAnnotations([
+      { type: 'reference-band', channel: 'y', from: 110, to: 90 },
+    ]);
+
+    expect(result.annotations).toHaveLength(0);
+    expect(result.diagnostics[0]?.code).toBe('INVALID_ANNOTATION_RANGE');
+  });
+
+  it('rejects a non-array annotations value without throwing', () => {
+    const result = normalizeAnnotations({ type: 'reference-line' });
+
+    expect(result.annotations).toEqual([]);
+    expect(result.diagnostics[0]?.code).toBe('INVALID_ANNOTATIONS');
+  });
+
+  it('rejects malformed entries and unsupported annotation types', () => {
+    const result = normalizeAnnotations([null, { type: 'custom', value: 100 }]);
+
+    expect(result.annotations).toEqual([]);
+    expect(result.diagnostics.map(({ code }) => code)).toEqual([
+      'INVALID_ANNOTATIONS',
+      'UNSUPPORTED_ANNOTATION_TYPE',
+    ]);
+  });
+
+  it('rejects missing targets and non-string callout labels without throwing', () => {
+    const result = normalizeAnnotations([
+      { type: 'highlight' },
+      { type: 'callout', target: { x: 'Q2' }, label: 31 },
+    ]);
+
+    expect(result.annotations).toEqual([]);
+    expect(result.diagnostics.map(({ code }) => code)).toEqual([
+      'INVALID_ANNOTATION_TARGET',
+      'INVALID_ANNOTATION_VALUE',
+    ]);
+  });
+
+  it('rejects invalid tones and non-string reference labels', () => {
+    const result = normalizeAnnotations([
+      { type: 'reference-line', channel: 'y', value: 100, tone: 'urgent' },
+      { type: 'reference-line', channel: 'y', value: 100, label: 100 },
+    ]);
+
+    expect(result.annotations).toEqual([]);
+    expect(result.diagnostics.map(({ code }) => code)).toEqual([
+      'INVALID_ANNOTATION_VALUE',
+      'INVALID_ANNOTATION_VALUE',
+    ]);
+  });
+});
+
+describe('compileCartesianAnnotations', () => {
+  it('compiles reference annotations into background marks', () => {
+    const result = compileCartesianAnnotations(
+      [
+        {
+          type: 'reference-band',
+          channel: 'y',
+          from: 90,
+          to: 110,
+          label: 'Normal',
+        },
+        {
+          type: 'reference-line',
+          channel: 'y',
+          value: 100,
+          label: 'Target',
+        },
+      ],
+      context,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.background.map(({ type }) => type)).toEqual(['rangeY', 'lineY']);
+    expect(result.background[0].data).toEqual([[90, 110]]);
+    expect(result.background[1].data).toEqual([100]);
+    expect(result.background[1].labels[0]).toEqual(
+      expect.objectContaining({
+        background: true,
+        backgroundFill: context.theme.background,
+        backgroundFillOpacity: 1,
+        backgroundPadding: [2, 4],
+      }),
+    );
+    expect(result.background[1].labels[0].stroke).toBeUndefined();
+  });
+
+  it('resolves a unique series target for highlight and callout', () => {
+    const result = compileCartesianAnnotations(
+      [
+        {
+          type: 'highlight',
+          target: { x: 'Q2', series: 'South' },
+          tone: 'warning',
+        },
+        {
+          type: 'callout',
+          target: { x: 'Q2', series: 'South' },
+          label: 'Growth 31%',
+          tone: 'warning',
+        },
+      ],
+      context,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.foreground).toHaveLength(2);
+    expect(result.foreground[0].data).toEqual([{ __annotation_x__: 'Q2', __annotation_y__: 145 }]);
+    expect(result.foreground[1].labels[0].text()).toBe('Growth 31%');
+  });
+
+  it('does not render ambiguous targets', () => {
+    const result = compileCartesianAnnotations(
+      [{ type: 'highlight', target: { x: 'Q2' } }],
+      context,
+    );
+
+    expect(result.foreground).toHaveLength(0);
+    expect(result.diagnostics[0]).toEqual(
+      expect.objectContaining({ code: 'AMBIGUOUS_ANNOTATION_TARGET' }),
+    );
+  });
+});

--- a/__tests__/line.test.ts
+++ b/__tests__/line.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let capturedOptionsList: any[] = [];
+
+vi.mock('@antv/g2', () => ({
+  Chart: class MockChart {
+    constructor() {}
+    options(options: any) {
+      capturedOptionsList.push(options);
+      return this;
+    }
+    render() {
+      return this;
+    }
+    destroy() {
+      return this;
+    }
+  },
+}));
+
 import { parse } from '../src/syntax/parser';
+import { Line } from '../src/vis/line';
 
 describe('parse - line chart', () => {
   it('should parse basic line chart', () => {
@@ -100,5 +120,78 @@ style
       lineWidth: 3,
       palette: ['#5B8FF9', '#61DDAA'],
     });
+  });
+});
+
+describe('Line annotations', () => {
+  beforeEach(() => {
+    capturedOptionsList = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('places reference annotations behind data and evidence annotations above data', () => {
+    const line = Line({ container: {} as HTMLElement, width: 640, height: 400 });
+
+    line.render({
+      type: 'line',
+      data: [
+        { time: 'Q1', value: 80, group: 'North' },
+        { time: 'Q2', value: 145, group: 'South' },
+      ],
+      annotations: [
+        {
+          type: 'reference-band',
+          channel: 'y',
+          from: 90,
+          to: 110,
+        },
+        {
+          type: 'reference-line',
+          channel: 'y',
+          value: 100,
+        },
+        {
+          type: 'highlight',
+          target: { x: 'Q2', series: 'South' },
+        },
+        {
+          type: 'callout',
+          target: { x: 'Q2', series: 'South' },
+          label: 'Growth 31%',
+        },
+      ],
+    });
+
+    const options = capturedOptionsList.at(-1);
+    expect(options.children.map(({ type }: any) => type)).toEqual([
+      'rangeY',
+      'lineY',
+      'line',
+      'point',
+      'point',
+      'point',
+    ]);
+  });
+
+  it('keeps rendering the line when an annotation target is invalid', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const line = Line({ container: {} as HTMLElement });
+
+    line.render({
+      data: [{ time: 'Q1', value: 80 }],
+      annotations: [
+        {
+          type: 'highlight',
+          target: { x: 'Q2' },
+        },
+      ],
+    });
+
+    const options = capturedOptionsList.at(-1);
+    expect(options.children.map(({ type }: any) => type)).toEqual(['line', 'point']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('ANNOTATION_TARGET_NOT_FOUND'));
   });
 });

--- a/src/annotation/cartesian.ts
+++ b/src/annotation/cartesian.ts
@@ -1,0 +1,281 @@
+import { CHART_FONT_FAMILY } from '../util/tokens';
+import { normalizeAnnotations } from './normalize';
+import type { ResolvedAnnotationTheme } from './theme';
+import type {
+  Annotation,
+  AnnotationDiagnostic,
+  AnnotationTone,
+  AnnotationValue,
+  CartesianAnnotationTarget,
+} from './types';
+
+export interface CartesianAnnotationContext<T> {
+  data: T[];
+  getX: (datum: T) => AnnotationValue;
+  getY: (datum: T) => number;
+  getSeries?: (datum: T) => string | undefined;
+  theme: ResolvedAnnotationTheme;
+}
+
+export interface CompiledAnnotations {
+  background: any[];
+  foreground: any[];
+  diagnostics: AnnotationDiagnostic[];
+}
+
+interface ResolvedTarget {
+  x: AnnotationValue;
+  y: number;
+}
+
+const getToneColor = (tone: AnnotationTone | undefined, theme: ResolvedAnnotationTheme) =>
+  theme.tones[tone ?? 'neutral'];
+
+const matchesTarget = <T>(
+  datum: T,
+  target: CartesianAnnotationTarget,
+  context: CartesianAnnotationContext<T>,
+): boolean => {
+  if (target.x !== undefined && context.getX(datum) !== target.x) return false;
+  if (target.y !== undefined && context.getY(datum) !== target.y) return false;
+  if (target.series !== undefined && context.getSeries?.(datum) !== target.series) return false;
+  return true;
+};
+
+const resolveTarget = <T>(
+  annotation: Extract<Annotation, { type: 'highlight' | 'callout' }>,
+  context: CartesianAnnotationContext<T>,
+): { target?: ResolvedTarget; diagnostic?: AnnotationDiagnostic } => {
+  const matches = context.data.filter((datum) => matchesTarget(datum, annotation.target, context));
+
+  if (matches.length === 0) {
+    return {
+      diagnostic: {
+        code: 'ANNOTATION_TARGET_NOT_FOUND',
+        message: `Target not found for ${annotation.type} annotation.`,
+      },
+    };
+  }
+
+  if (matches.length > 1) {
+    return {
+      diagnostic: {
+        code: 'AMBIGUOUS_ANNOTATION_TARGET',
+        message: `Target matched ${matches.length} data items for ${annotation.type} annotation.`,
+      },
+    };
+  }
+
+  const datum = matches[0];
+  return {
+    target: {
+      x: context.getX(datum),
+      y: context.getY(datum),
+    },
+  };
+};
+
+const getReferenceLabel = (
+  label: string | undefined,
+  channel: 'x' | 'y',
+  color: string,
+  theme: ResolvedAnnotationTheme,
+  fontSize: number,
+  fontWeight: number,
+  offset: number,
+) =>
+  label
+    ? [
+        {
+          text: () => label,
+          position: channel === 'y' ? 'right' : 'top',
+          fill: color,
+          fontFamily: CHART_FONT_FAMILY,
+          fontSize,
+          fontWeight,
+          background: true,
+          backgroundFill: theme.background,
+          backgroundFillOpacity: 1,
+          backgroundPadding: [2, 4],
+          backgroundRadius: 2,
+          ...(channel === 'y' ? { dx: -offset } : { dy: offset }),
+        },
+      ]
+    : undefined;
+
+const compileReferenceLine = (
+  annotation: Extract<Annotation, { type: 'reference-line' }>,
+  theme: ResolvedAnnotationTheme,
+) => {
+  const color = getToneColor(annotation.tone, theme);
+  return {
+    type: annotation.channel === 'y' ? 'lineY' : 'lineX',
+    data: [annotation.value],
+    animate: false,
+    tooltip: false,
+    legend: false,
+    style: {
+      stroke: color,
+      lineWidth: theme.referenceLine.lineWidth,
+      lineDash: theme.referenceLine.lineDash,
+      strokeOpacity: theme.referenceLine.opacity,
+    },
+    labels: getReferenceLabel(
+      annotation.label,
+      annotation.channel,
+      color,
+      theme,
+      theme.referenceLine.labelFontSize,
+      theme.referenceLine.labelFontWeight,
+      theme.referenceLine.labelOffset,
+    ),
+  };
+};
+
+const compileReferenceBand = (
+  annotation: Extract<Annotation, { type: 'reference-band' }>,
+  theme: ResolvedAnnotationTheme,
+) => {
+  const color = getToneColor(annotation.tone, theme);
+  return {
+    type: annotation.channel === 'y' ? 'rangeY' : 'rangeX',
+    data: [[annotation.from, annotation.to]],
+    animate: false,
+    tooltip: false,
+    legend: false,
+    style: {
+      fill: color,
+      fillOpacity: theme.referenceBand.fillOpacity,
+      strokeOpacity: 0,
+    },
+    labels: getReferenceLabel(
+      annotation.label,
+      annotation.channel,
+      color,
+      theme,
+      theme.referenceBand.labelFontSize,
+      theme.referenceBand.labelFontWeight,
+      theme.referenceBand.labelOffset,
+    ),
+  };
+};
+
+const compileHighlight = (
+  annotation: Extract<Annotation, { type: 'highlight' }>,
+  target: ResolvedTarget,
+  theme: ResolvedAnnotationTheme,
+) => {
+  const color = getToneColor(annotation.tone, theme);
+  return {
+    type: 'point',
+    data: [{ __annotation_x__: target.x, __annotation_y__: target.y }],
+    encode: {
+      x: '__annotation_x__',
+      y: '__annotation_y__',
+      shape: 'point',
+      size: theme.highlight.size,
+    },
+    animate: false,
+    tooltip: false,
+    legend: false,
+    style: {
+      fill: theme.background,
+      fillOpacity: theme.highlight.fillOpacity,
+      stroke: color,
+      lineWidth: theme.highlight.lineWidth,
+    },
+  };
+};
+
+const compileCallout = (
+  annotation: Extract<Annotation, { type: 'callout' }>,
+  target: ResolvedTarget,
+  theme: ResolvedAnnotationTheme,
+) => {
+  const color = getToneColor(annotation.tone, theme);
+  return {
+    type: 'point',
+    data: [{ __annotation_x__: target.x, __annotation_y__: target.y }],
+    encode: {
+      x: '__annotation_x__',
+      y: '__annotation_y__',
+      shape: 'point',
+      size: theme.callout.markerSize,
+    },
+    animate: false,
+    tooltip: false,
+    legend: false,
+    style: {
+      fill: theme.background,
+      stroke: color,
+      lineWidth: theme.callout.markerLineWidth,
+    },
+    labels: [
+      {
+        text: () => annotation.label,
+        position: 'top',
+        dx: theme.callout.offsetX,
+        dy: theme.callout.offsetY,
+        textAlign: 'left',
+        fill: theme.text,
+        fontFamily: CHART_FONT_FAMILY,
+        fontSize: theme.callout.labelFontSize,
+        fontWeight: theme.callout.labelFontWeight,
+        background: true,
+        backgroundFill: theme.background,
+        backgroundStroke: color,
+        backgroundLineWidth: 1,
+        backgroundPadding: theme.callout.labelPadding,
+        backgroundRadius: theme.callout.labelRadius,
+        connector: true,
+        connectorStroke: color,
+        connectorLineWidth: 1,
+        transform: [{ type: 'overlapHide' }],
+      },
+    ],
+  };
+};
+
+export const compileCartesianAnnotations = <T>(
+  annotations: Annotation[] | undefined,
+  context: CartesianAnnotationContext<T>,
+): CompiledAnnotations => {
+  const normalized = normalizeAnnotations(annotations);
+  const background: any[] = [];
+  const foreground: any[] = [];
+  const diagnostics = [...normalized.diagnostics];
+
+  for (const annotation of normalized.annotations) {
+    if (annotation.type === 'reference-band') {
+      background.push(compileReferenceBand(annotation, context.theme));
+      continue;
+    }
+
+    if (annotation.type === 'reference-line') {
+      background.push(compileReferenceLine(annotation, context.theme));
+      continue;
+    }
+
+    const resolved = resolveTarget(annotation, context);
+    if (resolved.diagnostic) {
+      diagnostics.push(resolved.diagnostic);
+      continue;
+    }
+
+    if (!resolved.target) continue;
+
+    foreground.push(
+      annotation.type === 'highlight'
+        ? compileHighlight(annotation, resolved.target, context.theme)
+        : compileCallout(annotation, resolved.target, context.theme),
+    );
+  }
+
+  return { background, foreground, diagnostics };
+};
+
+export const reportAnnotationDiagnostics = (diagnostics: AnnotationDiagnostic[]): void => {
+  for (const diagnostic of diagnostics) {
+    console.warn(`[GPT-Vis] ${diagnostic.code}: ${diagnostic.message}`);
+  }
+};

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -1,0 +1,19 @@
+export { compileCartesianAnnotations, reportAnnotationDiagnostics } from './cartesian';
+export { normalizeAnnotations } from './normalize';
+export { getAnnotationTheme } from './theme';
+export type { ResolvedAnnotationTheme } from './theme';
+export type {
+  AnnotatableConfig,
+  Annotation,
+  AnnotationBase,
+  AnnotationChannel,
+  AnnotationDiagnostic,
+  AnnotationDiagnosticCode,
+  AnnotationTone,
+  AnnotationValue,
+  CalloutAnnotation,
+  CartesianAnnotationTarget,
+  HighlightAnnotation,
+  ReferenceBandAnnotation,
+  ReferenceLineAnnotation,
+} from './types';

--- a/src/annotation/normalize.ts
+++ b/src/annotation/normalize.ts
@@ -1,0 +1,160 @@
+import type {
+  Annotation,
+  AnnotationDiagnostic,
+  AnnotationTone,
+  AnnotationValue,
+  CartesianAnnotationTarget,
+} from './types';
+
+export interface NormalizeAnnotationsResult {
+  annotations: Annotation[];
+  diagnostics: AnnotationDiagnostic[];
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isValidValue = (value: unknown): value is AnnotationValue =>
+  typeof value === 'string' ? value.length > 0 : Number.isFinite(value);
+
+const isValidTarget = (target: unknown): target is CartesianAnnotationTarget => {
+  if (!isRecord(target)) return false;
+
+  const hasChannel =
+    target.x !== undefined || target.y !== undefined || target.series !== undefined;
+  if (!hasChannel) return false;
+  if (target.x !== undefined && !isValidValue(target.x)) return false;
+  if (target.y !== undefined && !Number.isFinite(target.y)) return false;
+  return (
+    target.series === undefined || (typeof target.series === 'string' && target.series.length > 0)
+  );
+};
+
+const annotationTypes = new Set(['reference-line', 'reference-band', 'highlight', 'callout']);
+const annotationTones = new Set<AnnotationTone>([
+  'neutral',
+  'info',
+  'positive',
+  'warning',
+  'negative',
+]);
+
+const hasValidTone = (tone: unknown): tone is AnnotationTone | undefined =>
+  tone === undefined || (typeof tone === 'string' && annotationTones.has(tone as AnnotationTone));
+
+const hasValidOptionalLabel = (label: unknown): label is string | undefined =>
+  label === undefined || typeof label === 'string';
+
+export const normalizeAnnotations = (annotations: unknown): NormalizeAnnotationsResult => {
+  const normalized: Annotation[] = [];
+  const diagnostics: AnnotationDiagnostic[] = [];
+
+  if (annotations === undefined) return { annotations: normalized, diagnostics };
+
+  if (!Array.isArray(annotations)) {
+    diagnostics.push({
+      code: 'INVALID_ANNOTATIONS',
+      message: 'Annotations must be an array.',
+    });
+    return { annotations: normalized, diagnostics };
+  }
+
+  for (const [index, annotation] of annotations.entries()) {
+    if (!isRecord(annotation)) {
+      diagnostics.push({
+        code: 'INVALID_ANNOTATIONS',
+        message: `Annotation at index ${index} must be an object.`,
+      });
+      continue;
+    }
+
+    if (annotation.visible === false) continue;
+
+    if (typeof annotation.type !== 'string' || !annotationTypes.has(annotation.type)) {
+      diagnostics.push({
+        code: 'UNSUPPORTED_ANNOTATION_TYPE',
+        message: `Unsupported annotation type at index ${index}.`,
+      });
+      continue;
+    }
+
+    if (!hasValidTone(annotation.tone)) {
+      diagnostics.push({
+        code: 'INVALID_ANNOTATION_VALUE',
+        message: `Invalid annotation tone at index ${index}.`,
+      });
+      continue;
+    }
+
+    if (annotation.type === 'reference-line') {
+      if (
+        (annotation.channel !== 'x' && annotation.channel !== 'y') ||
+        !isValidValue(annotation.value) ||
+        !hasValidOptionalLabel(annotation.label)
+      ) {
+        diagnostics.push({
+          code: 'INVALID_ANNOTATION_VALUE',
+          message: `Invalid reference line at index ${index}.`,
+        });
+        continue;
+      }
+
+      normalized.push(annotation as unknown as Annotation);
+      continue;
+    }
+
+    if (annotation.type === 'reference-band') {
+      if (annotation.channel !== 'x' && annotation.channel !== 'y') {
+        diagnostics.push({
+          code: 'INVALID_ANNOTATION_RANGE',
+          message: `Invalid reference band at index ${index}.`,
+        });
+        continue;
+      }
+
+      const validValues =
+        isValidValue(annotation.from) &&
+        isValidValue(annotation.to) &&
+        hasValidOptionalLabel(annotation.label);
+      const matchingTypes = typeof annotation.from === typeof annotation.to;
+      const validNumericRange =
+        typeof annotation.from !== 'number' || annotation.from < (annotation.to as number);
+      const validStringRange =
+        typeof annotation.from !== 'string' || annotation.from !== annotation.to;
+
+      if (!validValues || !matchingTypes || !validNumericRange || !validStringRange) {
+        diagnostics.push({
+          code: 'INVALID_ANNOTATION_RANGE',
+          message: `Invalid reference band at index ${index}.`,
+        });
+        continue;
+      }
+
+      normalized.push(annotation as unknown as Annotation);
+      continue;
+    }
+
+    if (!isValidTarget(annotation.target)) {
+      diagnostics.push({
+        code: 'INVALID_ANNOTATION_TARGET',
+        message: `Invalid annotation target at index ${index}.`,
+      });
+      continue;
+    }
+
+    if (
+      annotation.type === 'callout' &&
+      (typeof annotation.label !== 'string' || !annotation.label.trim())
+    ) {
+      diagnostics.push({
+        code: 'INVALID_ANNOTATION_VALUE',
+        message: `Callout label is required at index ${index}.`,
+      });
+      continue;
+    }
+
+    normalized.push(annotation as unknown as Annotation);
+  }
+
+  return { annotations: normalized, diagnostics };
+};

--- a/src/annotation/theme.ts
+++ b/src/annotation/theme.ts
@@ -1,0 +1,107 @@
+import type { VisualizationTheme } from '../types';
+import { getChartVisualTokens } from '../util/tokens';
+import type { AnnotationTone } from './types';
+
+export interface ResolvedAnnotationTheme {
+  tones: Record<AnnotationTone, string>;
+  referenceLine: {
+    lineWidth: number;
+    lineDash: number[];
+    opacity: number;
+    labelFontSize: number;
+    labelFontWeight: number;
+    labelOffset: number;
+  };
+  referenceBand: {
+    fillOpacity: number;
+    labelFontSize: number;
+    labelFontWeight: number;
+    labelOffset: number;
+  };
+  highlight: {
+    size: number;
+    lineWidth: number;
+    fillOpacity: number;
+  };
+  callout: {
+    markerSize: number;
+    markerLineWidth: number;
+    labelFontSize: number;
+    labelFontWeight: number;
+    labelPadding: number[];
+    labelRadius: number;
+    offsetX: number;
+    offsetY: number;
+  };
+  background: string;
+  text: string;
+}
+
+const LIGHT_TONES: Record<AnnotationTone, string> = {
+  neutral: '#667085',
+  info: '#5B6CFF',
+  positive: '#2DAF9E',
+  warning: '#D97706',
+  negative: '#DC2626',
+};
+
+const DARK_TONES: Record<AnnotationTone, string> = {
+  neutral: '#A7AFBE',
+  info: '#8B9AFF',
+  positive: '#4AD7C3',
+  warning: '#F2B84B',
+  negative: '#FF8585',
+};
+
+const ACADEMY_TONES: Record<AnnotationTone, string> = {
+  neutral: '#626975',
+  info: '#4E79A7',
+  positive: '#59A14F',
+  warning: '#F28E2C',
+  negative: '#E15759',
+};
+
+const getTones = (theme: VisualizationTheme): Record<AnnotationTone, string> => {
+  if (theme === 'dark') return DARK_TONES;
+  if (theme === 'academy') return ACADEMY_TONES;
+  return LIGHT_TONES;
+};
+
+export const getAnnotationTheme = (theme: VisualizationTheme): ResolvedAnnotationTheme => {
+  const tokens = getChartVisualTokens(theme);
+
+  return {
+    tones: getTones(theme),
+    referenceLine: {
+      lineWidth: 1.5,
+      lineDash: [5, 4],
+      opacity: 0.9,
+      labelFontSize: 11,
+      labelFontWeight: 500,
+      labelOffset: 6,
+    },
+    referenceBand: {
+      fillOpacity: theme === 'dark' ? 0.14 : 0.1,
+      labelFontSize: 11,
+      labelFontWeight: 500,
+      labelOffset: 6,
+    },
+    highlight: {
+      size: 8,
+      lineWidth: 3,
+      fillOpacity: 1,
+    },
+    callout: {
+      markerSize: 6,
+      markerLineWidth: 2.5,
+      labelFontSize: 11,
+      labelFontWeight: 500,
+      labelPadding: [5, 8],
+      labelRadius: theme === 'academy' ? 0 : 4,
+      offsetX: 12,
+      offsetY: -18,
+    },
+    background: tokens.background,
+    text: tokens.textPrimary,
+  };
+};

--- a/src/annotation/types.ts
+++ b/src/annotation/types.ts
@@ -1,0 +1,63 @@
+export type AnnotationValue = string | number;
+
+export type AnnotationTone = 'neutral' | 'info' | 'positive' | 'warning' | 'negative';
+
+export type AnnotationChannel = 'x' | 'y';
+
+export interface CartesianAnnotationTarget {
+  x?: AnnotationValue;
+  y?: number;
+  series?: string;
+}
+
+export interface AnnotationBase {
+  visible?: boolean;
+  tone?: AnnotationTone;
+}
+
+export interface ReferenceLineAnnotation extends AnnotationBase {
+  type: 'reference-line';
+  channel: AnnotationChannel;
+  value: AnnotationValue;
+  label?: string;
+}
+
+export interface ReferenceBandAnnotation extends AnnotationBase {
+  type: 'reference-band';
+  channel: AnnotationChannel;
+  from: AnnotationValue;
+  to: AnnotationValue;
+  label?: string;
+}
+
+export interface HighlightAnnotation extends AnnotationBase {
+  type: 'highlight';
+  target: CartesianAnnotationTarget;
+}
+
+export interface CalloutAnnotation extends AnnotationBase {
+  type: 'callout';
+  target: CartesianAnnotationTarget;
+  label: string;
+}
+
+export type Annotation =
+  ReferenceLineAnnotation | ReferenceBandAnnotation | HighlightAnnotation | CalloutAnnotation;
+
+export interface AnnotatableConfig {
+  annotations?: Annotation[];
+}
+
+export type AnnotationDiagnosticCode =
+  | 'INVALID_ANNOTATIONS'
+  | 'UNSUPPORTED_ANNOTATION_TYPE'
+  | 'INVALID_ANNOTATION_VALUE'
+  | 'INVALID_ANNOTATION_RANGE'
+  | 'INVALID_ANNOTATION_TARGET'
+  | 'ANNOTATION_TARGET_NOT_FOUND'
+  | 'AMBIGUOUS_ANNOTATION_TARGET';
+
+export interface AnnotationDiagnostic {
+  code: AnnotationDiagnosticCode;
+  message: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,12 @@
+export type {
+  Annotation,
+  AnnotationTone,
+  CalloutAnnotation,
+  CartesianAnnotationTarget,
+  HighlightAnnotation,
+  ReferenceBandAnnotation,
+  ReferenceLineAnnotation,
+} from './annotation';
 export { GPTVis } from './gpt-vis';
 export type { GPTVisConfig } from './gpt-vis';
 export { isVisSyntax, parse } from './syntax';

--- a/src/vis/line/index.ts
+++ b/src/vis/line/index.ts
@@ -1,4 +1,10 @@
 import { Chart } from '@antv/g2';
+import {
+  compileCartesianAnnotations,
+  getAnnotationTheme,
+  reportAnnotationDiagnostics,
+  type AnnotatableConfig,
+} from '../../annotation';
 import type { VisualizationOptions, VisualizationTheme } from '../../types';
 import {
   CHART_STYLE_DEFAULTS,
@@ -25,7 +31,7 @@ export type LineDataItem = {
 /**
  * LineConfig defines the configuration for rendering the line chart.
  */
-export interface LineConfig {
+export interface LineConfig extends AnnotatableConfig {
   type?: 'line';
   data: LineDataItem[];
   title?: string;
@@ -83,7 +89,15 @@ export const Line = (options: VisualizationOptions): LineInstance => {
    * Render the line chart with the given configuration.
    */
   const render = (config: LineConfig): void => {
-    const { data = [], theme = chartTheme, title, axisXTitle, axisYTitle, style = {} } = config;
+    const {
+      data = [],
+      annotations,
+      theme = chartTheme,
+      title,
+      axisXTitle,
+      axisYTitle,
+      style = {},
+    } = config;
 
     // Clean up previous chart if exists
     if (chart) {
@@ -132,7 +146,7 @@ export const Line = (options: VisualizationOptions): LineInstance => {
       encode = { x: 'time', y: 'value' };
     }
 
-    const children: any[] = [
+    const dataChildren: any[] = [
       {
         type: 'line',
         tooltip,
@@ -148,7 +162,7 @@ export const Line = (options: VisualizationOptions): LineInstance => {
 
     const showPoints = data.length <= (hasGroupField ? 36 : 24);
     if (showPoints) {
-      children.push({
+      dataChildren.push({
         type: 'point',
         encode: {
           x: 'time',
@@ -166,6 +180,24 @@ export const Line = (options: VisualizationOptions): LineInstance => {
         },
       });
     }
+
+    const compiledAnnotations = compileCartesianAnnotations(annotations, {
+      data,
+      getX: (datum) => datum.time,
+      getY: (datum) => datum.value,
+      getSeries: (datum) => datum.group,
+      theme: getAnnotationTheme(theme),
+    });
+
+    if (compiledAnnotations.diagnostics.length > 0) {
+      reportAnnotationDiagnostics(compiledAnnotations.diagnostics);
+    }
+
+    const children = [
+      ...compiledAnnotations.background,
+      ...dataChildren,
+      ...compiledAnnotations.foreground,
+    ];
 
     // Configure chart options
     // Note: Using 'any' type due to G2's complex type system with transformations


### PR DESCRIPTION
- 为 GPT-Vis 建立通用 Annotation 系统，并完成 Line 图表的首个适配版本
<img width="2140" height="974" alt="image" src="https://github.com/user-attachments/assets/883dc827-1cb8-49d5-91de-3b8d8c82479b" />


## 里程碑

| 阶段 | 目标 | 当前状态 |
| --- | --- | --- |
| V0.1 | 定义通用 Annotation 协议，完成 Line 图表和四类基础标注 | ✅ 本 PR 已完成 |
| V0.2 | 将通用协议适配到其他笛卡尔图表，如 Area、Column、Bar、Scatter | ⏳ 待开始 |
| V0.3 | 扩展饼图、漏斗图、关系图等非笛卡尔图表的目标定位与标注能力 | ⏳ 待开始 |
| V0.4 | 增加统一的全局图表样式定制，包括 Annotation、坐标轴等视觉配置 | ⏳ 待开始 |
| V0.5 | 增加 Annotation 事件和结构化 diagnostics，支持上层应用联动 | ⏳ 待开始 |

## 新增标注类型

| 英文名 | 中文名 | 作用 |
| --- | --- | --- |
| `reference-line` | 参考线 | 在指定的 X 或 Y 值上绘制参考线，例如目标线、均值线或事件时间线 |
| `reference-band` | 参考区间 | 标记一段连续的 X 或 Y 范围，例如正常区间、目标区间或活动周期 |
| `highlight` | 数据高亮 | 强调图表中的指定数据点，突出异常值或关键数据 |
| `callout` | 文字标注 | 在指定数据点旁显示解释文字，说明变化原因或分析结论 |

## 配置说明

```ts
{
  type: 'reference-band',
  channel: 'y',
  from: 90,
  to: 110,
  label: '健康区间',
  tone: 'positive',
}
```

| 参数 | 示例值 | 作用 |
| --- | --- | --- |
| `type` | `'reference-band'` | 指定 Annotation 类型为参考区间，用连续色带标记一段范围 |
| `channel` | `'y'` | 指定区间作用于 Y 轴；设置为 `'x'` 时表示 X 轴区间 |
| `from` | `90` | 区间起始值 |
| `to` | `110` | 区间结束值，必须与 `from` 类型一致且大于起始值 |
| `label` | `'健康区间'` | 显示在参考区间旁的说明文字，可选 |
| `tone` | `'positive'` | 使用正向语义色呈现标注；还支持 `neutral`、`info`、`warning`、`negative` |
